### PR TITLE
[Feat] derive serde for proving key

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -73,6 +73,7 @@ criterion = "0.3"
 gumdrop = "0.8"
 proptest = "1"
 rand_core = { version = "0.6", features = ["getrandom"] }
+rand_chacha = "0.3.1"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -62,6 +62,7 @@ rustc-hash = "1.1.0"
 sha3 = "0.9.1"
 ark-std = { version = "0.3.0", features = ["print-trace"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+bincode = "1.3.3"
 
 # Developer tooling dependencies
 plotters = { version = "0.3.0", optional = true }

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -61,6 +61,7 @@ blake2b_simd = "1"
 rustc-hash = "1.1.0"
 sha3 = "0.9.1"
 ark-std = { version = "0.3.0", features = ["print-trace"], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 # Developer tooling dependencies
 plotters = { version = "0.3.0", optional = true }

--- a/halo2_proofs/examples/serialization.rs
+++ b/halo2_proofs/examples/serialization.rs
@@ -133,7 +133,7 @@ fn main() -> std::io::Result<()> {
     let vk = keygen_vk(&params, &circuit).expect("vk should not fail");
     let pk = keygen_pk(&params, vk, &circuit).expect("pk should not fail");
 
-    for buf_size in [1024, 1024 * 1024, 1024 * 1024 * 1024] {
+    for buf_size in [1024, 8 * 1024, 1024 * 1024, 1024 * 1024 * 1024] {
         println!("buf_size: {buf_size}");
         // Using halo2_proofs serde implementation
         let f = File::create("serialization-test.pk")?;

--- a/halo2_proofs/examples/shuffle.rs
+++ b/halo2_proofs/examples/shuffle.rs
@@ -338,7 +338,7 @@ fn main() {
             K,
             circuit.clone(),
             Err(vec![(
-                ((1, "z should end with 1").into(), 0, "").into(),
+                ((1, "z should end with 1").into(), 0, "".to_owned()).into(),
                 FailureLocation::InRegion {
                     region: (0, "Shuffle original into shuffled").into(),
                     offset: 32,

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -834,9 +834,9 @@ impl<F: FieldExt> MockProver<F> {
                                 Value::Real(x) if x.is_zero_vartime() => None,
                                 Value::Real(_) => Some(VerifyFailure::ConstraintNotSatisfied {
                                     constraint: (
-                                        (gate_index, gate.name()).into(),
+                                        (gate_index, gate.name().to_string()).into(),
                                         poly_index,
-                                        gate.constraint_name(poly_index),
+                                        gate.constraint_name(poly_index).to_string(),
                                     )
                                         .into(),
                                     location: FailureLocation::find_expressions(
@@ -860,9 +860,9 @@ impl<F: FieldExt> MockProver<F> {
                                 }),
                                 Value::Poison => Some(VerifyFailure::ConstraintPoisoned {
                                     constraint: (
-                                        (gate_index, gate.name()).into(),
+                                        (gate_index, gate.name().to_string()).into(),
                                         poly_index,
-                                        gate.constraint_name(poly_index),
+                                        gate.constraint_name(poly_index).to_string(),
                                     )
                                         .into(),
                                 }),
@@ -995,7 +995,7 @@ impl<F: FieldExt> MockProver<F> {
                                 assert!(table.binary_search(input).is_err());
 
                                 Some(VerifyFailure::Lookup {
-                                    name: lookup.name,
+                                    name: lookup.name.clone(),
                                     lookup_index,
                                     location: FailureLocation::find_expressions(
                                         &self.cs,
@@ -1146,7 +1146,7 @@ impl<F: FieldExt> MockProver<F> {
                                             None
                                         } else {
                                             Some(VerifyFailure::CellNotAssigned {
-                                                gate: (gate_index, gate.name()).into(),
+                                                gate: (gate_index, gate.name().to_string()).into(),
                                                 region: (
                                                     r_i,
                                                     r.name.clone(),
@@ -1225,9 +1225,9 @@ impl<F: FieldExt> MockProver<F> {
                                 Value::Real(x) if x.is_zero_vartime() => None,
                                 Value::Real(_) => Some(VerifyFailure::ConstraintNotSatisfied {
                                     constraint: (
-                                        (gate_index, gate.name()).into(),
+                                        (gate_index, gate.name().to_string()).into(),
                                         poly_index,
-                                        gate.constraint_name(poly_index),
+                                        gate.constraint_name(poly_index).to_string(),
                                     )
                                         .into(),
                                     location: FailureLocation::find_expressions(
@@ -1251,9 +1251,9 @@ impl<F: FieldExt> MockProver<F> {
                                 }),
                                 Value::Poison => Some(VerifyFailure::ConstraintPoisoned {
                                     constraint: (
-                                        (gate_index, gate.name()).into(),
+                                        (gate_index, gate.name().to_string()).into(),
                                         poly_index,
-                                        gate.constraint_name(poly_index),
+                                        gate.constraint_name(poly_index).to_string(),
                                     )
                                         .into(),
                                 }),
@@ -1374,7 +1374,7 @@ impl<F: FieldExt> MockProver<F> {
                         .filter_map(move |(input, input_row)| {
                             if table.binary_search(input).is_err() {
                                 Some(VerifyFailure::Lookup {
-                                    name: lookup.name,
+                                    name: lookup.name.clone(),
                                     lookup_index,
                                     location: FailureLocation::find_expressions(
                                         &self.cs,
@@ -1781,7 +1781,7 @@ mod tests {
         assert_eq!(
             prover.verify(),
             Err(vec![VerifyFailure::Lookup {
-                name: "lookup",
+                name: "lookup".to_owned(),
                 lookup_index: 0,
                 location: FailureLocation::InRegion {
                     region: (1, "Faulty synthesis").into(),
@@ -1913,7 +1913,7 @@ mod tests {
         assert_eq!(
             prover.verify(),
             Err(vec![VerifyFailure::Lookup {
-                name: "lookup",
+                name: "lookup".to_owned(),
                 lookup_index: 0,
                 location: FailureLocation::InRegion {
                     region: (2, "Faulty synthesis").into(),
@@ -2030,7 +2030,7 @@ mod tests {
         assert_eq!(
             prover.verify(),
             Err(vec![VerifyFailure::ConstraintNotSatisfied {
-                constraint: ((0, "Equality check").into(), 0, "").into(),
+                constraint: ((0, "Equality check".to_owned()).into(), 0, "".to_owned()).into(),
                 location: FailureLocation::InRegion {
                     region: (1, "Wrong synthesis").into(),
                     offset: 0,

--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -162,7 +162,7 @@ pub enum VerifyFailure {
     /// A lookup input did not exist in its corresponding table.
     Lookup {
         /// The name of the lookup that is not satisfied.
-        name: &'static str,
+        name: String,
         /// The index of the lookup that is not satisfied. These indices are assigned in
         /// the order in which `ConstraintSystem::lookup` is called during
         /// `Circuit::configure`.
@@ -280,7 +280,7 @@ impl Debug for VerifyFailure {
                 };
 
                 let debug = ConstraintCaseDebug {
-                    constraint: *constraint,
+                    constraint: constraint.clone(),
                     location: location.clone(),
                     cell_values: cell_values
                         .iter()

--- a/halo2_proofs/src/dev/gates.rs
+++ b/halo2_proofs/src/dev/gates.rs
@@ -15,14 +15,14 @@ use crate::{
 
 #[derive(Debug)]
 struct Constraint {
-    name: &'static str,
+    name: String,
     expression: String,
     queries: BTreeSet<String>,
 }
 
 #[derive(Debug)]
 struct Gate {
-    name: &'static str,
+    name: String,
     constraints: Vec<Constraint>,
 }
 
@@ -112,13 +112,13 @@ impl CircuitGates {
             .gates
             .iter()
             .map(|gate| Gate {
-                name: gate.name(),
+                name: gate.name().to_owned(),
                 constraints: gate
                     .polynomials()
                     .iter()
                     .enumerate()
                     .map(|(i, constraint)| Constraint {
-                        name: gate.constraint_name(i),
+                        name: gate.constraint_name(i).to_owned(),
                         expression: constraint.evaluate(
                             &util::format_value,
                             &|selector| format!("S{}", selector.0),

--- a/halo2_proofs/src/dev/metadata.rs
+++ b/halo2_proofs/src/dev/metadata.rs
@@ -1,5 +1,7 @@
 //! Metadata about circuits.
 
+use serde::{Deserialize, Serialize};
+
 use super::metadata::Column as ColumnMetadata;
 use crate::plonk::{self, Any};
 use std::{
@@ -7,7 +9,7 @@ use std::{
     fmt::{self, Debug},
 };
 /// Metadata about a column within a circuit.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Column {
     /// The type of the column.
     pub(super) column_type: Any,
@@ -149,14 +151,14 @@ impl fmt::Display for DebugVirtualCell {
 }
 
 /// Metadata about a configured gate within a circuit.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Gate {
     /// The index of the active gate. These indices are assigned in the order in which
     /// `ConstraintSystem::create_gate` is called during `Circuit::configure`.
     pub(super) index: usize,
     /// The name of the active gate. These are specified by the gate creator (such as
     /// a chip implementation), and is not enforced to be unique.
-    pub(super) name: &'static str,
+    pub(super) name: String,
 }
 
 impl fmt::Display for Gate {
@@ -165,14 +167,23 @@ impl fmt::Display for Gate {
     }
 }
 
-impl From<(usize, &'static str)> for Gate {
-    fn from((index, name): (usize, &'static str)) -> Self {
+impl From<(usize, String)> for Gate {
+    fn from((index, name): (usize, String)) -> Self {
         Gate { index, name }
     }
 }
 
+impl From<(usize, &'static str)> for Gate {
+    fn from((index, name): (usize, &'static str)) -> Self {
+        Gate {
+            index,
+            name: name.to_owned(),
+        }
+    }
+}
+
 /// Metadata about a configured constraint within a circuit.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Constraint {
     /// The gate containing the constraint.
     pub(super) gate: Gate,
@@ -182,7 +193,7 @@ pub struct Constraint {
     pub(super) index: usize,
     /// The name of the constraint. This is specified by the gate creator (such as a chip
     /// implementation), and is not enforced to be unique.
-    pub(super) name: &'static str,
+    pub(super) name: String,
 }
 
 impl fmt::Display for Constraint {
@@ -202,8 +213,8 @@ impl fmt::Display for Constraint {
     }
 }
 
-impl From<(Gate, usize, &'static str)> for Constraint {
-    fn from((gate, index, name): (Gate, usize, &'static str)) -> Self {
+impl From<(Gate, usize, String)> for Constraint {
+    fn from((gate, index, name): (Gate, usize, String)) -> Self {
         Constraint { gate, index, name }
     }
 }

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -8,6 +8,7 @@
 use blake2b_simd::Params as Blake2bParams;
 use ff::PrimeField;
 use group::ff::Field;
+use serde::{Deserialize, Serialize};
 
 use crate::arithmetic::{CurveAffine, FieldExt};
 use crate::helpers::{
@@ -150,7 +151,11 @@ pub fn log_info(msg: String) {
 
 /// This is a verifying key which allows for the verification of proofs for a
 /// particular circuit.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "C::Scalar: Serialize, C: Serialize",
+    deserialize = "C::Scalar: Deserialize<'de>, C: Deserialize<'de>"
+))]
 pub struct VerifyingKey<C: CurveAffine> {
     domain: EvaluationDomain<C::Scalar>,
     fixed_commitments: Vec<C>,
@@ -365,7 +370,11 @@ pub struct PinnedVerificationKey<'a, C: CurveAffine> {
 }
 /// This is a proving key which allows for the creation of proofs for a
 /// particular circuit.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "C::Scalar: Serialize, C: Serialize",
+    deserialize = "C::Scalar: Deserialize<'de>, C: Deserialize<'de>"
+))]
 pub struct ProvingKey<C: CurveAffine> {
     vk: VerifyingKey<C>,
     l0: Polynomial<C::Scalar, ExtendedLagrangeCoeff>,

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -84,6 +84,7 @@ pub(crate) mod sealed {
             assert!(self.0 < 2, "The API only supports three phases");
             Phase(self.0 + 1)
         }
+        #[allow(clippy::wrong_self_convention)]
         pub fn to_u8(&self) -> u8 {
             self.0
         }

--- a/halo2_proofs/src/plonk/evaluation.rs
+++ b/halo2_proofs/src/plonk/evaluation.rs
@@ -312,6 +312,7 @@ impl<C: CurveAffine> Evaluator<C> {
         let p = &pk.vk.cs.permutation;
 
         // Calculate the advice and instance cosets
+        #[cfg(feature = "profile")]
         let start = start_measure("cosets", false);
         let advice: Vec<Vec<Polynomial<C::Scalar, ExtendedLagrangeCoeff>>> = advice_polys
             .iter()
@@ -331,7 +332,7 @@ impl<C: CurveAffine> Evaluator<C> {
                     .collect()
             })
             .collect();
-        stop_measure(start);
+        // stop_measure(start);
 
         let mut values = domain.empty_extended();
 
@@ -344,7 +345,7 @@ impl<C: CurveAffine> Evaluator<C> {
             .zip(permutations.iter())
         {
             // Custom gates
-            let start = start_measure("custom gates", false);
+            // let start = start_measure("custom gates", false);
             multicore::scope(|scope| {
                 let chunk_size = (size + num_threads - 1) / num_threads;
                 for (thread_idx, values) in values.chunks_mut(chunk_size).enumerate() {
@@ -372,9 +373,11 @@ impl<C: CurveAffine> Evaluator<C> {
                     });
                 }
             });
+            #[cfg(feature = "profile")]
             stop_measure(start);
 
             // Permutations
+            #[cfg(feature = "profile")]
             let start = start_measure("permutations", false);
             let sets = &permutation.sets;
             if !sets.is_empty() {
@@ -456,9 +459,11 @@ impl<C: CurveAffine> Evaluator<C> {
                     }
                 });
             }
+            #[cfg(feature = "profile")]
             stop_measure(start);
 
             // Lookups
+            #[cfg(feature = "profile")]
             let start = start_measure("lookups", false);
             for (n, lookup) in lookups.iter().enumerate() {
                 // Polynomials required for this lookup.
@@ -529,6 +534,7 @@ impl<C: CurveAffine> Evaluator<C> {
                     }
                 });
             }
+            #[cfg(feature = "profile")]
             stop_measure(start);
         }
         values

--- a/halo2_proofs/src/plonk/evaluation.rs
+++ b/halo2_proofs/src/plonk/evaluation.rs
@@ -16,6 +16,7 @@ use group::{
     ff::{BatchInvert, Field},
     Curve,
 };
+use serde::{Deserialize, Serialize};
 use std::any::TypeId;
 use std::convert::TryInto;
 use std::num::ParseIntError;
@@ -34,7 +35,7 @@ fn get_rotation_idx(idx: usize, rot: i32, rot_scale: i32, isize: i32) -> usize {
 }
 
 /// Value used in a calculation
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Serialize, Deserialize)]
 pub enum ValueSource {
     /// This is a constant value
     Constant(usize),
@@ -106,7 +107,7 @@ impl ValueSource {
 }
 
 /// Calculation
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Calculation {
     /// This is an addition
     Add(ValueSource, ValueSource),
@@ -180,7 +181,11 @@ impl Calculation {
 }
 
 /// Evaluator
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "C::Scalar: Serialize",
+    deserialize = "C::Scalar: Deserialize<'de>"
+))]
 pub struct Evaluator<C: CurveAffine> {
     ///  Custom gates evalution
     pub custom_gates: GraphEvaluator<C>,
@@ -189,7 +194,11 @@ pub struct Evaluator<C: CurveAffine> {
 }
 
 /// GraphEvaluator
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "C::Scalar: Serialize",
+    deserialize = "C::Scalar: Deserialize<'de>"
+))]
 pub struct GraphEvaluator<C: CurveAffine> {
     /// Constants
     pub constants: Vec<C::ScalarExt>,
@@ -211,7 +220,7 @@ pub struct EvaluationData<C: CurveAffine> {
 }
 
 /// CaluclationInfo
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CalculationInfo {
     /// Calculation
     pub calculation: Calculation,

--- a/halo2_proofs/src/plonk/lookup.rs
+++ b/halo2_proofs/src/plonk/lookup.rs
@@ -1,13 +1,14 @@
 use super::circuit::Expression;
 use ff::Field;
+use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug};
 
 pub(crate) mod prover;
 pub(crate) mod verifier;
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Argument<F: Field> {
-    pub(crate) name: &'static str,
+    pub(crate) name: String,
     pub(crate) input_expressions: Vec<Expression<F>>,
     pub(crate) table_expressions: Vec<Expression<F>>,
 }
@@ -28,7 +29,7 @@ impl<F: Field> Argument<F> {
     pub fn new(name: &'static str, table_map: Vec<(Expression<F>, Expression<F>)>) -> Self {
         let (input_expressions, table_expressions) = table_map.into_iter().unzip();
         Argument {
-            name,
+            name: name.to_string(),
             input_expressions,
             table_expressions,
         }

--- a/halo2_proofs/src/plonk/permutation.rs
+++ b/halo2_proofs/src/plonk/permutation.rs
@@ -17,11 +17,12 @@ pub(crate) mod prover;
 pub(crate) mod verifier;
 
 pub use keygen::Assembly;
+use serde::{Deserialize, Serialize};
 
 use std::io;
 
 /// A permutation argument.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Argument {
     /// A sequence of columns involved in the argument.
     pub(super) columns: Vec<Column<Any>>,
@@ -83,7 +84,7 @@ impl Argument {
 }
 
 /// The verifying key for a single permutation argument.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct VerifyingKey<C: CurveAffine> {
     commitments: Vec<C>,
 }
@@ -123,7 +124,11 @@ impl<C: CurveAffine> VerifyingKey<C> {
 }
 
 /// The proving key for a single permutation argument.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "C::Scalar: Serialize",
+    deserialize = "C::Scalar: Deserialize<'de>"
+))]
 pub(crate) struct ProvingKey<C: CurveAffine> {
     permutations: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
     polys: Vec<Polynomial<C::Scalar, Coeff>>,

--- a/halo2_proofs/src/plonk/permutation/keygen.rs
+++ b/halo2_proofs/src/plonk/permutation/keygen.rs
@@ -175,7 +175,7 @@ impl Assembly {
         {
             let omega = domain.get_omega();
             parallelize(&mut omega_powers, |o, start| {
-                let mut cur = omega.pow_vartime(&[start as u64]);
+                let mut cur = omega.pow_vartime([start as u64]);
                 for v in o.iter_mut() {
                     *v = cur;
                     cur *= &omega;
@@ -187,7 +187,7 @@ impl Assembly {
         let mut deltaomega = vec![omega_powers; p.columns.len()];
         {
             parallelize(&mut deltaomega, |o, start| {
-                let mut cur = C::Scalar::DELTA.pow_vartime(&[start as u64]);
+                let mut cur = C::Scalar::DELTA.pow_vartime([start as u64]);
                 for omega_powers in o.iter_mut() {
                     for v in omega_powers {
                         *v *= &cur;

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -11,7 +11,6 @@ use std::marker::PhantomData;
 use std::ops::RangeTo;
 use std::rc::Rc;
 use std::sync::atomic::AtomicUsize;
-use std::time::Instant;
 use std::{collections::HashMap, iter, mem, sync::atomic::Ordering};
 
 use super::{
@@ -753,6 +752,7 @@ where
     #[cfg(feature = "profile")]
     let multiopen_time = start_timer!(|| "Phase 5: multiopen");
     let prover = P::new(params);
+    #[allow(clippy::let_and_return)]
     let multiopen_res = prover
         .create_proof(&mut rng, transcript, instances)
         .map_err(|_| Error::ConstraintSystemFailure);

--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -10,6 +10,7 @@ use crate::SerdeFormat;
 use ff::PrimeField;
 use group::ff::{BatchInvert, Field};
 use halo2curves::FieldExt;
+use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::io;
 use std::marker::PhantomData;
@@ -65,7 +66,7 @@ impl Basis for ExtendedLagrangeCoeff {}
 
 /// Represents a univariate polynomial defined over a field and a particular
 /// basis.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Polynomial<F, B> {
     pub(crate) values: Vec<F>,
     _marker: PhantomData<B>,
@@ -353,7 +354,7 @@ impl<'a, F: Field, B: Basis> Sub<F> for &'a Polynomial<F, B> {
 /// Describes the relative rotation of a vector. Negative numbers represent
 /// reverse (leftmost) rotations and positive numbers represent forward (rightmost)
 /// rotations. Zero represents no rotation.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Rotation(pub i32);
 
 impl Rotation {

--- a/halo2_proofs/src/poly/domain.rs
+++ b/halo2_proofs/src/poly/domain.rs
@@ -10,6 +10,7 @@ use crate::{
 use super::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial, Rotation};
 
 use group::ff::{BatchInvert, Field, PrimeField};
+use serde::{Deserialize, Serialize};
 
 use std::{env::var, marker::PhantomData};
 
@@ -24,7 +25,7 @@ fn get_fft_mode() -> usize {
 }
 
 /// FFTStage
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FFTStage {
     radix: usize,
     length: usize,
@@ -65,7 +66,7 @@ pub fn get_stages(size: usize, radixes: Vec<usize>) -> Vec<FFTStage> {
 }
 
 /// FFTData
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 struct FFTData<F: FieldExt> {
     n: usize,
 
@@ -409,7 +410,7 @@ fn recursive_fft<F: FieldExt>(data: &FFTData<F>, data_in: &mut Vec<F>, inverse: 
 /// This structure contains precomputed constants and other details needed for
 /// performing operations on an evaluation domain of size $2^k$ and an extended
 /// domain of size $2^{k} * j$ with $j \neq 0$.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EvaluationDomain<G: Group> {
     n: u64,
     k: u32,

--- a/halo2_proofs/src/transcript.rs
+++ b/halo2_proofs/src/transcript.rs
@@ -239,12 +239,12 @@ impl<R: Read, C: CurveAffine> Transcript<C, Challenge255<C>>
     for Keccak256Read<R, C, Challenge255<C>>
 {
     fn squeeze_challenge(&mut self) -> Challenge255<C> {
-        self.state.update(&[KECCAK256_PREFIX_CHALLENGE]);
+        self.state.update([KECCAK256_PREFIX_CHALLENGE]);
 
         let mut state_lo = self.state.clone();
         let mut state_hi = self.state.clone();
-        state_lo.update(&[KECCAK256_PREFIX_CHALLENGE_LO]);
-        state_hi.update(&[KECCAK256_PREFIX_CHALLENGE_HI]);
+        state_lo.update([KECCAK256_PREFIX_CHALLENGE_LO]);
+        state_hi.update([KECCAK256_PREFIX_CHALLENGE_HI]);
         let result_lo: [u8; 32] = state_lo.finalize().as_slice().try_into().unwrap();
         let result_hi: [u8; 32] = state_hi.finalize().as_slice().try_into().unwrap();
 
@@ -256,7 +256,7 @@ impl<R: Read, C: CurveAffine> Transcript<C, Challenge255<C>>
     }
 
     fn common_point(&mut self, point: C) -> io::Result<()> {
-        self.state.update(&[KECCAK256_PREFIX_POINT]);
+        self.state.update([KECCAK256_PREFIX_POINT]);
         let coords: Coordinates<C> = Option::from(point.coordinates()).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::Other,
@@ -270,7 +270,7 @@ impl<R: Read, C: CurveAffine> Transcript<C, Challenge255<C>>
     }
 
     fn common_scalar(&mut self, scalar: C::Scalar) -> io::Result<()> {
-        self.state.update(&[KECCAK256_PREFIX_SCALAR]);
+        self.state.update([KECCAK256_PREFIX_SCALAR]);
         self.state.update(scalar.to_repr().as_ref());
 
         Ok(())
@@ -401,12 +401,12 @@ impl<W: Write, C: CurveAffine> Transcript<C, Challenge255<C>>
     for Keccak256Write<W, C, Challenge255<C>>
 {
     fn squeeze_challenge(&mut self) -> Challenge255<C> {
-        self.state.update(&[KECCAK256_PREFIX_CHALLENGE]);
+        self.state.update([KECCAK256_PREFIX_CHALLENGE]);
 
         let mut state_lo = self.state.clone();
         let mut state_hi = self.state.clone();
-        state_lo.update(&[KECCAK256_PREFIX_CHALLENGE_LO]);
-        state_hi.update(&[KECCAK256_PREFIX_CHALLENGE_HI]);
+        state_lo.update([KECCAK256_PREFIX_CHALLENGE_LO]);
+        state_hi.update([KECCAK256_PREFIX_CHALLENGE_HI]);
         let result_lo: [u8; 32] = state_lo.finalize().as_slice().try_into().unwrap();
         let result_hi: [u8; 32] = state_hi.finalize().as_slice().try_into().unwrap();
 
@@ -418,7 +418,7 @@ impl<W: Write, C: CurveAffine> Transcript<C, Challenge255<C>>
     }
 
     fn common_point(&mut self, point: C) -> io::Result<()> {
-        self.state.update(&[KECCAK256_PREFIX_POINT]);
+        self.state.update([KECCAK256_PREFIX_POINT]);
         let coords: Coordinates<C> = Option::from(point.coordinates()).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::Other,
@@ -432,7 +432,7 @@ impl<W: Write, C: CurveAffine> Transcript<C, Challenge255<C>>
     }
 
     fn common_scalar(&mut self, scalar: C::Scalar) -> io::Result<()> {
-        self.state.update(&[KECCAK256_PREFIX_SCALAR]);
+        self.state.update([KECCAK256_PREFIX_SCALAR]);
         self.state.update(scalar.to_repr().as_ref());
 
         Ok(())

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -1,7 +1,9 @@
 #![allow(clippy::many_single_char_names)]
 #![allow(clippy::op_ref)]
+#![allow(unused_macros)]
+#![allow(dead_code)]
 
-use assert_matches::assert_matches;
+// use assert_matches::assert_matches;
 use halo2_proofs::arithmetic::{Field, FieldExt};
 use halo2_proofs::circuit::{Cell, Layouter, SimpleFloorPlanner, Value};
 use halo2_proofs::dev::MockProver;

--- a/primitives/poseidon/src/poseidon.rs
+++ b/primitives/poseidon/src/poseidon.rs
@@ -25,6 +25,7 @@ impl<F: FieldExt, const T: usize, const RATE: usize> Poseidon<F, T, RATE> {
     pub fn update(&mut self, elements: &[F]) {
         let mut input_elements = self.absorbing.clone();
         input_elements.extend_from_slice(elements);
+        dbg!(&input_elements);
 
         for chunk in input_elements.chunks(RATE) {
             if chunk.len() < RATE {
@@ -32,12 +33,14 @@ impl<F: FieldExt, const T: usize, const RATE: usize> Poseidon<F, T, RATE> {
                 // absorbation line
                 self.absorbing = chunk.to_vec();
             } else {
+                dbg!(&self.state);
                 // Add new chunk of inputs for the next permutation cycle.
                 for (input_element, state) in chunk.iter().zip(self.state.0.iter_mut().skip(1)) {
                     state.add_assign(input_element);
                 }
                 // Perform intermediate permutation
                 self.spec.permute(&mut self.state);
+                dbg!(&self.state);
                 // Flush the absorption line
                 self.absorbing.clear();
             }
@@ -62,6 +65,7 @@ impl<F: FieldExt, const T: usize, const RATE: usize> Poseidon<F, T, RATE> {
 
         // Perform final permutation
         self.spec.permute(&mut self.state);
+        dbg!(&self.state);
         // Flush the absorption line
         self.absorbing.clear();
         // Returns the challenge while preserving internal state

--- a/primitives/poseidon/src/spec.rs
+++ b/primitives/poseidon/src/spec.rs
@@ -12,7 +12,7 @@ impl<F: FieldExt, const T: usize> Default for State<F, T> {
     /// The capacity value is 2**64 + (o − 1) where o the output length.
     fn default() -> Self {
         let mut state = [F::zero(); T];
-        state[0] = F::from_u128(1 << 64);
+        state[0] = F::from_u128(1u128 << 64);
         State(state)
     }
 }
@@ -349,10 +349,7 @@ impl<F: FieldExt, const T: usize, const RATE: usize> Spec<F, T, RATE> {
             *optimized = tmp[0];
 
             tmp[0] = F::zero();
-            for ((acc, tmp), constant) in acc
-                .iter_mut()
-                .zip(tmp.into_iter())
-                .zip(constants.iter())
+            for ((acc, tmp), constant) in acc.iter_mut().zip(tmp.into_iter()).zip(constants.iter())
             {
                 *acc = tmp + constant
             }


### PR DESCRIPTION
Macbook Pro M1Max
```
cargo run --example serialization

k: 22, extended_k: 23

buf_size: 1024 (1kb)
SerdeFormat::RawBytes pk write time: 9.442123375s
SerdeFormat::RawBytes pk read time: 3.664672958s
The size of the file is 5100274316 bytes

bincode pk write time: 12.883031s
bincode pk read time: 4.773148791s
The size of the file is 5905587221 bytes


buf_size: 8192 (8kb)
SerdeFormat::RawBytes pk write time: 3.030109958s
SerdeFormat::RawBytes pk read time: 1.883050208s
The size of the file is 5100274316 bytes

bincode pk write time: 3.30306475s
bincode pk read time: 2.689354458s
The size of the file is 5905587221 bytes


buf_size: 1048576 (1mb)
SerdeFormat::RawBytes pk write time: 1.6365095s
SerdeFormat::RawBytes pk read time: 1.566943458s
The size of the file is 5100274316 bytes

bincode pk write time: 1.590803833s
bincode pk read time: 2.351837791s
The size of the file is 5905587221 bytes


buf_size: 1073741824 (1gb)
SerdeFormat::RawBytes pk write time: 1.634263541s
SerdeFormat::RawBytes pk read time: 1.665291291s
The size of the file is 5100274316 bytes

bincode pk write time: 1.760522083s
bincode pk read time: 2.485505916s
The size of the file is 5905587221 bytes
```

Ubuntu c6a.metal
```
k: 22, extended_k: 23
buf_size: 1024
SerdeFormat::RawBytes pk write time: 7.181348219s
SerdeFormat::RawBytes pk read time: 3.243197832s
The size of the file is 5100274316 bytes
bincode pk write time: 8.273701355s
bincode pk read time: 4.67558756s
The size of the file is 5905587221 bytes
buf_size: 8192
SerdeFormat::RawBytes pk write time: 3.791338683s
SerdeFormat::RawBytes pk read time: 2.309466145s
The size of the file is 5100274316 bytes
bincode pk write time: 3.704418194s
bincode pk read time: 3.729152971s
The size of the file is 5905587221 bytes
buf_size: 1048576
SerdeFormat::RawBytes pk write time: 3.30082691s
SerdeFormat::RawBytes pk read time: 2.106349607s
The size of the file is 5100274316 bytes
bincode pk write time: 2.783368942s
bincode pk read time: 3.58548298s
The size of the file is 5905587221 bytes
buf_size: 1073741824
SerdeFormat::RawBytes pk write time: 3.81766919s
SerdeFormat::RawBytes pk read time: 3.696294414s
The size of the file is 5100274316 bytes
bincode pk write time: 3.332019878s
bincode pk read time: 5.48401095s
The size of the file is 5905587221 bytes
```

`BufReader::new` default buffer size is only 8kb! https://doc.rust-lang.org/std/io/struct.BufReader.html

Todo:

- [ ] Try using `rkyv` deserialization: https://github.com/djkoloski/rust_serialization_benchmark 
- [ ] This would require changing the `serde::{Serialize, Deserialize}` import in `halo2curves` to `rkyv` as well.