### PR TITLE
feat: add back `io::Result` handling for read/write

### DIFF
--- a/halo2_proofs/benches/commit_zk.rs
+++ b/halo2_proofs/benches/commit_zk.rs
@@ -29,7 +29,7 @@ fn rand_poly_serial(mut rng: ChaCha20Rng, domain: usize) -> Vec<Scalar> {
 
 fn rand_poly_par(mut rng: ChaCha20Rng, domain: usize) -> Vec<Scalar> {
     // Sample a random polynomial of degree n - 1
-    let n = 1usize << domain as usize;
+    let n = 1usize << domain;
     let mut random_poly = vec![Scalar::ZERO; n];
 
     let num_threads = current_num_threads();

--- a/halo2_proofs/examples/serialization.rs
+++ b/halo2_proofs/examples/serialization.rs
@@ -135,16 +135,17 @@ fn main() {
     let vk = keygen_vk(&params, &circuit).expect("vk should not fail");
     let pk = keygen_pk(&params, vk, &circuit).expect("pk should not fail");
 
+    let format = SerdeFormat::RawBytes;
     let f = File::create("serialization-test.pk").unwrap();
     let mut writer = BufWriter::new(f);
-    pk.write(&mut writer, SerdeFormat::RawBytes).unwrap();
+    pk.write(&mut writer, format).unwrap();
     writer.flush().unwrap();
 
     let f = File::open("serialization-test.pk").unwrap();
     let mut reader = BufReader::new(f);
     let pk = {
         circuit.params();
-        ProvingKey::<G1Affine>::read::<_, StandardPlonk>(&mut reader, SerdeFormat::RawBytes, ())
+        ProvingKey::<G1Affine>::read::<_, StandardPlonk>(&mut reader, format, ())
     }
     .unwrap();
 

--- a/halo2_proofs/src/circuit/table_layouter.rs
+++ b/halo2_proofs/src/circuit/table_layouter.rs
@@ -82,7 +82,7 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> TableLayouter<F>
 
         let entry = self.default_and_assigned.entry(column).or_default();
 
-        let mut value = Value::unknown();
+        let value;
         self.cs.assign_fixed(
             // annotation,
             column.inner(),

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -857,7 +857,7 @@ impl<F: FromUniformBytes<64> + Ord> MockProver<F> {
                 .flat_map(|(gate_index, gate)| {
                     let blinding_rows =
                         (self.n as usize - (self.cs.blinding_factors() + 1))..(self.n as usize);
-                    (gate_row_ids.clone().chain(blinding_rows.into_iter())).flat_map(move |row| {
+                    (gate_row_ids.clone().chain(blinding_rows)).flat_map(move |row| {
                         let row = row as i32 + n;
                         gate.polynomials().iter().enumerate().filter_map(
                             move |(poly_index, poly)| match poly.evaluate_lazy(

--- a/halo2_proofs/src/plonk/permutation.rs
+++ b/halo2_proofs/src/plonk/permutation.rs
@@ -93,27 +93,28 @@ impl<C: CurveAffine> VerifyingKey<C> {
         &self.commitments
     }
 
-    pub(crate) fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat)
+    pub(crate) fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()>
     where
         C: SerdeCurveAffine,
     {
         for commitment in &self.commitments {
-            commitment.write(writer, format);
+            commitment.write(writer, format)?;
         }
+        Ok(())
     }
 
     pub(crate) fn read<R: io::Read>(
         reader: &mut R,
         argument: &Argument,
         format: SerdeFormat,
-    ) -> Self
+    ) -> io::Result<Self>
     where
         C: SerdeCurveAffine,
     {
         let commitments = (0..argument.columns.len())
             .map(|_| C::read(reader, format))
-            .collect();
-        VerifyingKey { commitments }
+            .collect::<io::Result<Vec<_>>>()?;
+        Ok(VerifyingKey { commitments })
     }
 
     pub(crate) fn bytes_length(&self) -> usize {

--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -171,7 +171,9 @@ impl<F: SerdePrimeField, B> Polynomial<F, B> {
         reader.read_exact(&mut poly_len).unwrap();
         let poly_len = u32::from_be_bytes(poly_len);
         Self {
-            values: (0..poly_len).map(|_| F::read(reader, format)).collect(),
+            values: (0..poly_len)
+                .map(|_| F::read(reader, format).unwrap())
+                .collect(),
             _marker: PhantomData,
         }
     }
@@ -182,7 +184,7 @@ impl<F: SerdePrimeField, B> Polynomial<F, B> {
             .write_all(&(self.values.len() as u32).to_be_bytes())
             .unwrap();
         for value in self.values.iter() {
-            value.write(writer, format);
+            value.write(writer, format).unwrap();
         }
     }
 }

--- a/halo2_proofs/src/poly/domain.rs
+++ b/halo2_proofs/src/poly/domain.rs
@@ -298,6 +298,7 @@ pub fn butterfly_4_parallel<F: Field>(
 }
 
 /// Inner recursion
+#[allow(clippy::too_many_arguments)]
 fn recursive_fft_inner<F: Field>(
     data_in: &[F],
     data_out: &mut [F],
@@ -986,7 +987,6 @@ fn test_l_i() {
 
 #[test]
 fn test_fft() {
-    use crate::arithmetic::{eval_polynomial, lagrange_interpolate};
     use halo2curves::pasta::pallas::Scalar;
     use rand_core::OsRng;
 


### PR DESCRIPTION
Only `unwrap` for `RawBytesUnchecked` format. This is now more aligned by upstream PSE version.