### PR TITLE
`SingleChipLayouter`: panic if `assign_region` is called more than once

### DIFF
--- a/halo2_proofs/src/circuit/floor_planner/single_pass.rs
+++ b/halo2_proofs/src/circuit/floor_planner/single_pass.rs
@@ -44,6 +44,8 @@ pub struct SingleChipLayouter<'a, F: Field, CS: Assignment<F> + 'a> {
     // Stores the starting row for each region.
     // Edit: modify to just one region with RegionStart(0)
     // regions: Vec<RegionStart>,
+    // `assign_region` must only be called once.
+    region_assigned: bool,
     /// Stores the first empty row for each column.
     columns: FxHashMap<RegionColumn, usize>,
     /// Stores the table fixed columns.
@@ -67,6 +69,7 @@ impl<'a, F: Field, CS: Assignment<F>> SingleChipLayouter<'a, F, CS> {
             cs,
             constants,
             // regions: vec![],
+            region_assigned: false,
             columns: FxHashMap::default(),
             table_columns: vec![],
             _marker: PhantomData,
@@ -86,6 +89,10 @@ impl<'a, F: Field, CS: Assignment<F> + 'a + SyncDeps> Layouter<F>
         N: Fn() -> NR,
         NR: Into<String>,
     {
+        assert!(
+            !self.region_assigned,
+            "Only a single region can be assigned per layouter."
+        );
         /*
         let region_index = self.regions.len();
 
@@ -147,6 +154,8 @@ impl<'a, F: Field, CS: Assignment<F> + 'a + SyncDeps> Layouter<F>
                 *next_constant_row += 1;
             }
         }
+
+        self.region_assigned = true;
 
         Ok(result)
     }


### PR DESCRIPTION
Currently, calling `assign_region` more than once on a `SingleChipLayouter` silently overwrites the existing region.