### PR TITLE
Revert "`SingleChipLayouter`: panic if `assign_region` is called more than once"

### DIFF
--- a/halo2_proofs/src/circuit/floor_planner/single_pass.rs
+++ b/halo2_proofs/src/circuit/floor_planner/single_pass.rs
@@ -44,8 +44,6 @@ pub struct SingleChipLayouter<'a, F: Field, CS: Assignment<F> + 'a> {
     // Stores the starting row for each region.
     // Edit: modify to just one region with RegionStart(0)
     // regions: Vec<RegionStart>,
-    // `assign_region` must only be called once.
-    region_assigned: bool,
     /// Stores the first empty row for each column.
     columns: FxHashMap<RegionColumn, usize>,
     /// Stores the table fixed columns.
@@ -69,7 +67,6 @@ impl<'a, F: Field, CS: Assignment<F>> SingleChipLayouter<'a, F, CS> {
             cs,
             constants,
             // regions: vec![],
-            region_assigned: false,
             columns: FxHashMap::default(),
             table_columns: vec![],
             _marker: PhantomData,
@@ -89,10 +86,6 @@ impl<'a, F: Field, CS: Assignment<F> + 'a + SyncDeps> Layouter<F>
         N: Fn() -> NR,
         NR: Into<String>,
     {
-        assert!(
-            !self.region_assigned,
-            "Only a single region can be assigned per layouter."
-        );
         /*
         let region_index = self.regions.len();
 
@@ -154,8 +147,6 @@ impl<'a, F: Field, CS: Assignment<F> + 'a + SyncDeps> Layouter<F>
                 *next_constant_row += 1;
             }
         }
-
-        self.region_assigned = true;
 
         Ok(result)
     }


### PR DESCRIPTION
Reverts axiom-crypto/halo2#20

We actually do allow the behavior where `assign_region` is called multiple times: we do this when using multiple sub-circuits **with entirely disjoint columns**. There is no security concern since the proof will fail, but it mean an unknowing user may face an unknown failure. However to have the optimization of not calling `assign_region` twice always but still have the flexibility of assigning different sub-circuits, we will continue allowing this functionality.