### PR TITLE
[feat] shared base MSM many

### DIFF
--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -144,6 +144,12 @@ impl<F, B> DerefMut for Polynomial<F, B> {
     }
 }
 
+impl<F, B> AsRef<Polynomial<F, B>> for Polynomial<F, B> {
+    fn as_ref(&self) -> &Polynomial<F, B> {
+        self
+    }
+}
+
 impl<F, B> Polynomial<F, B> {
     /// Iterate over the values, which are either in coefficient or evaluation
     /// form depending on the basis `B`.

--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -66,6 +66,19 @@ pub trait Params<'params, C: CurveAffine>: Sized + Clone {
         r: Blind<C::ScalarExt>,
     ) -> C::CurveExt;
 
+    fn commit_lagrange_many(
+        &self,
+        polys: &[impl AsRef<Polynomial<C::ScalarExt, LagrangeCoeff>> + Sync],
+        r: Vec<Blind<C::ScalarExt>>,
+    ) -> Vec<C::CurveExt> {
+        assert_eq!(polys.len(), r.len());
+        polys
+            .iter()
+            .zip(r)
+            .map(|(poly, r)| self.commit_lagrange(poly.as_ref(), r))
+            .collect()
+    }
+
     /// Writes params to a buffer.
     fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()>;
 

--- a/halo2_proofs/src/poly/kzg/commitment.rs
+++ b/halo2_proofs/src/poly/kzg/commitment.rs
@@ -1,4 +1,4 @@
-use crate::arithmetic::{best_multiexp, g_to_lagrange, parallelize};
+use crate::arithmetic::{best_multiexp, best_multiexp_shared_bases, g_to_lagrange, parallelize};
 use crate::helpers::SerdeCurveAffine;
 use crate::poly::commitment::{Blind, CommitmentScheme, Params, ParamsProver, ParamsVerifier};
 use crate::poly::{Coeff, LagrangeCoeff, Polynomial};
@@ -303,6 +303,19 @@ where
         let size = poly.len();
         assert!(self.n() >= size as u64);
         best_multiexp(poly, &self.g_lagrange[0..size])
+    }
+
+    fn commit_lagrange_many(
+        &self,
+        polys: &[impl AsRef<Polynomial<E::Fr, LagrangeCoeff>> + Sync],
+        _: Vec<Blind<<E::G1Affine as halo2curves::CurveAffine>::ScalarExt>>,
+    ) -> Vec<E::G1> {
+        if polys.is_empty() {
+            return vec![];
+        }
+        let size = polys[0].as_ref().len();
+        assert!(self.n() >= size as u64);
+        best_multiexp_shared_bases(polys, &self.g_lagrange[0..size])
     }
 
     /// Writes params to a buffer.


### PR DESCRIPTION
An untested hypothesis is that when the number of columns is high, the current version of doing `best_multiexp` one column at a time is not optimal because it is not memory local and doesn't use the fact that the base of the MSM is always the same (namely the KZG params).

This is a quick edit so that for a batch of columns, when we `commit_lagrange` we do all MSM for a chunk of the `bases` in a single thread.

Haven't tested it on any wide circuits to compare.