### PR TITLE
[chore] use rayon work-stealing to improve `evaluate_h`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,28 @@ jobs:
           command: test
           args: --verbose --release --all --all-features
 
+  build:
+    name: Build target ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - wasm32-unknown-unknown
+          - wasm32-wasi
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          override: false
+      - name: Add target
+        run: rustup target add ${{ matrix.target }}
+      - name: cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --no-default-features --features batch,circuit-params --target ${{ matrix.target }}
+
   example:
     name: Examples on ubuntu
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
     strategy:
       matrix:
         target:
-          - wasm32-unknown-unknown
           - wasm32-wasi
 
     steps:

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -93,7 +93,7 @@ ark-std = { version = "0.3.0", features = ["print-trace"] }
 getrandom = { version = "0.2", features = ["js"] }
 
 [features]
-default = ["batch", "multicore", "circuit-params", "profile"]
+default = ["batch", "multicore", "circuit-params"]
 multicore = ["maybe-rayon/threads"]
 dev-graph = ["plotters", "tabbycat"]
 test-dev-graph = ["dev-graph", "plotters/bitmap_backend", "plotters/bitmap_encoder", "plotters/ttf"]

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2-axiom"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
     "Sean Bowe <sean@electriccoin.co>",
     "Ying Tong Lai <yingtong@electriccoin.co>",

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -6,7 +6,9 @@ authors = [
     "Ying Tong Lai <yingtong@electriccoin.co>",
     "Daira Hopwood <daira@electriccoin.co>",
     "Jack Grigg <jack@electriccoin.co>",
-    "Privacy Scaling Explorations team", "Taiko Labs", "Intrinsic Technologies"
+    "Privacy Scaling Explorations team",
+    "Taiko Labs",
+    "Intrinsic Technologies",
 ]
 edition = "2021"
 rust-version = "1.73.0"
@@ -63,7 +65,7 @@ group = "0.13"
 pairing = "0.23"
 halo2curves = { package = "halo2curves-axiom", version = "0.4.2", default-features = false, features = ["bits", "bn256-table", "derive_serde"] }
 rand = "0.8"
-rand_core = { version = "0.6", default-features = false}
+rand_core = { version = "0.6", default-features = false }
 tracing = "0.1"
 blake2b_simd = "1"
 rustc-hash = "1.1"
@@ -91,15 +93,10 @@ ark-std = { version = "0.3.0", features = ["print-trace"] }
 getrandom = { version = "0.2", features = ["js"] }
 
 [features]
-default = ["batch", "multicore", "circuit-params"]
+default = ["batch", "multicore", "circuit-params", "profile"]
 multicore = ["maybe-rayon/threads"]
 dev-graph = ["plotters", "tabbycat"]
-test-dev-graph = [
-    "dev-graph",
-    "plotters/bitmap_backend",
-    "plotters/bitmap_encoder",
-    "plotters/ttf",
-]
+test-dev-graph = ["dev-graph", "plotters/bitmap_backend", "plotters/bitmap_encoder", "plotters/ttf"]
 gadget-traces = ["backtrace"]
 # thread-safe-region = []
 sanity-checks = []

--- a/halo2_proofs/src/fft.rs
+++ b/halo2_proofs/src/fft.rs
@@ -52,6 +52,18 @@ mod tests {
         );
         end_timer!(start);
 
+        let mut c = input.clone();
+        let l_c = c.len();
+        let start = start_timer!(|| format!("parallel fft {} ({})", a.len(), num_threads));
+        fft::parallel::fft(
+            &mut c,
+            domain.get_omega(),
+            k,
+            domain.get_fft_data(l_c),
+            false,
+        );
+        end_timer!(start);
+
         let mut b = input;
         let l_b = b.len();
         let start = start_timer!(|| format!("recursive fft {} ({})", a.len(), num_threads));
@@ -67,6 +79,7 @@ mod tests {
         for i in 0..n {
             //log_info(format!("{}: {} {}", i, a[i], b[i]));
             assert_eq!(a[i], b[i]);
+            assert_eq!(a[i], c[i]);
         }
     }
 

--- a/halo2_proofs/src/fft.rs
+++ b/halo2_proofs/src/fft.rs
@@ -17,6 +17,10 @@ pub fn fft<Scalar: Field, G: FftGroup<Scalar>>(
     data: &FFTData<Scalar>,
     inverse: bool,
 ) {
+    // Empirically, the parallel implementation requires less memory bandwidth, which is more performant on x86_64.
+    #[cfg(target_arch = "x86_64")]
+    parallel::fft(a, omega, log_n, data, inverse);
+    #[cfg(not(target_arch = "x86_64"))]
     recursive::fft(a, omega, log_n, data, inverse)
 }
 


### PR DESCRIPTION
I have no idea how rayon work-stealing works, but by adding some `par_iter`s to the multiple FFTs, it has improved the performance substantially on machines with large numbers of cores.

We have also discovered that Scroll's `parallel` FFT is better than the `recursive` FFT on `c7a` machines (8xl up to 48xl). So we use `cfg(target_arch = "x86_64")` to select which one to use now.