### PR TITLE
chore: update `halo2curves` to v0.5.0

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2-axiom"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
     "Sean Bowe <sean@electriccoin.co>",
     "Ying Tong Lai <yingtong@electriccoin.co>",
@@ -63,7 +63,7 @@ crossbeam = "0.8"
 ff = "0.13"
 group = "0.13"
 pairing = "0.23"
-halo2curves = { package = "halo2curves-axiom", version = "0.4.2", default-features = false, features = ["bits", "bn256-table", "derive_serde"] }
+halo2curves = { package = "halo2curves-axiom", version = "0.5.0", default-features = false, features = ["bits", "bn256-table", "derive_serde"] }
 rand = "0.8"
 rand_core = { version = "0.6", default-features = false }
 tracing = "0.1"


### PR DESCRIPTION
Rust respects major version changes, so update `halo2curves`  after https://github.com/axiom-crypto/halo2curves/pull/19