### PR TITLE
Typo fix CHANGELOG.md

### DIFF
--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -132,7 +132,7 @@ All APIs that represented witnessed values as `Option<V>` now represent them as
     directly, and returns `VerificationStrategy::Output` instead of `Guard`.
   - `ConstraintSystem::enable_equality` and `ConstraintSystem::query_any` now
     take `Into<Column<Any>>` instead of `Column<Any>` as a parameter to avoid
-    excesive `.into()` usage.
+    excessive `.into()` usage.
   - `Error` has been overhauled:
     - `Error` now implements `std::fmt::Display` and `std::error::Error`.
     - `Error` no longer implements `PartialEq`. Tests can check for specific


### PR DESCRIPTION
# Pull Request Title
**Typo fix in CHANGELOG.md**

## Description
This PR fixes a typo in the `CHANGELOG.md` file. The word "excesive" has been corrected to "excessive".

## Changes
- **File:** `halo2_proofs/CHANGELOG.md`
- **Line:** 132
- **Change:** Replaced "excesive" with "excessive"

**Thank you for reviewing my pull request!**