### PR TITLE
fix: patch the query collision bug in multipoint opening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "halo2-axiom"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ark-std",
  "assert_matches",

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2-axiom"
-version = "0.5.0"
+version = "0.5.1"
 authors = [
     "Sean Bowe <sean@electriccoin.co>",
     "Ying Tong Lai <yingtong@electriccoin.co>",

--- a/halo2_proofs/src/poly/ipa/multiopen.rs
+++ b/halo2_proofs/src/poly/ipa/multiopen.rs
@@ -4,7 +4,10 @@
 //! [halo]: https://eprint.iacr.org/2019/1021
 
 use super::*;
-use crate::{poly::query::Query, transcript::ChallengeScalar};
+use crate::{
+    poly::query::{exists_query_collision, Query},
+    transcript::ChallengeScalar,
+};
 use ff::Field;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -59,10 +62,16 @@ type IntermediateSets<F, Q> = (
     Vec<Vec<F>>,
 );
 
-fn construct_intermediate_sets<F: Field + Ord, I, Q: Query<F>>(queries: I) -> IntermediateSets<F, Q>
+fn construct_intermediate_sets<F: Field + Ord, I, Q: Query<F>>(
+    queries: I,
+) -> Option<IntermediateSets<F, Q>>
 where
     I: IntoIterator<Item = Q> + Clone,
 {
+    let queries = queries.into_iter().collect::<Vec<_>>();
+    if exists_query_collision(&queries) {
+        return None;
+    }
     // Construct sets of unique commitments and corresponding information about
     // their queries.
     let mut commitment_map: Vec<CommitmentData<Q::Eval, Q::Commitment>> = vec![];
@@ -168,5 +177,5 @@ where
         }
     }
 
-    (commitment_map, point_sets)
+    Some((commitment_map, point_sets))
 }

--- a/halo2_proofs/src/poly/ipa/multiopen/prover.rs
+++ b/halo2_proofs/src/poly/ipa/multiopen/prover.rs
@@ -40,7 +40,12 @@ impl<'params, C: CurveAffine> Prover<'params, IPACommitmentScheme<C>> for Prover
         let x_1: ChallengeX1<_> = transcript.squeeze_challenge_scalar();
         let x_2: ChallengeX2<_> = transcript.squeeze_challenge_scalar();
 
-        let (poly_map, point_sets) = construct_intermediate_sets(queries);
+        let (poly_map, point_sets) = construct_intermediate_sets(queries).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "queries iterator contains mismatching evaluations",
+            )
+        })?;
 
         // Collapse openings at same point sets together into single openings using
         // x_1 challenge.

--- a/halo2_proofs/src/poly/ipa/multiopen/verifier.rs
+++ b/halo2_proofs/src/poly/ipa/multiopen/verifier.rs
@@ -47,7 +47,8 @@ impl<'params, C: CurveAffine> Verifier<'params, IPACommitmentScheme<C>>
         // polynomial terms linearly independent.
         let x_2: ChallengeX2<_> = transcript.squeeze_challenge_scalar();
 
-        let (commitment_map, point_sets) = construct_intermediate_sets(queries);
+        let (commitment_map, point_sets) =
+            construct_intermediate_sets(queries).ok_or(Error::OpeningError)?;
 
         // Compress the commitments and expected evaluations at x together.
         // using the challenge x_1

--- a/halo2_proofs/src/poly/kzg/multiopen/gwc.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/gwc.rs
@@ -4,7 +4,10 @@ mod verifier;
 pub use prover::ProverGWC;
 pub use verifier::VerifierGWC;
 
-use crate::{poly::query::Query, transcript::ChallengeScalar};
+use crate::{
+    poly::query::{exists_query_collision, Query},
+    transcript::ChallengeScalar,
+};
 use ff::Field;
 use std::marker::PhantomData;
 
@@ -22,10 +25,16 @@ struct CommitmentData<F: Field, Q: Query<F>> {
     _marker: PhantomData<F>,
 }
 
-fn construct_intermediate_sets<F: Field, I, Q: Query<F>>(queries: I) -> Vec<CommitmentData<F, Q>>
+fn construct_intermediate_sets<F: Field, I, Q: Query<F>>(
+    queries: I,
+) -> Option<Vec<CommitmentData<F, Q>>>
 where
     I: IntoIterator<Item = Q> + Clone,
 {
+    let queries = queries.into_iter().collect::<Vec<_>>();
+    if exists_query_collision(&queries) {
+        return None;
+    }
     let mut point_query_map: Vec<(F, Vec<Q>)> = Vec::new();
     for query in queries {
         if let Some(pos) = point_query_map
@@ -39,12 +48,13 @@ where
         }
     }
 
-    point_query_map
+    let sets = point_query_map
         .into_iter()
         .map(|(point, queries)| CommitmentData {
             queries,
             point,
             _marker: PhantomData,
         })
-        .collect()
+        .collect();
+    Some(sets)
 }

--- a/halo2_proofs/src/poly/kzg/multiopen/gwc/prover.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/gwc/prover.rs
@@ -51,7 +51,12 @@ where
         R: RngCore,
     {
         let v: ChallengeV<_> = transcript.squeeze_challenge_scalar();
-        let commitment_data = construct_intermediate_sets(queries);
+        let commitment_data = construct_intermediate_sets(queries).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "queries iterator contains mismatching evaluations",
+            )
+        })?;
 
         for commitment_at_a_point in commitment_data.iter() {
             let z = commitment_at_a_point.point;

--- a/halo2_proofs/src/poly/kzg/multiopen/gwc/verifier.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/gwc/verifier.rs
@@ -53,7 +53,7 @@ where
     {
         let v: ChallengeV<_> = transcript.squeeze_challenge_scalar();
 
-        let commitment_data = construct_intermediate_sets(queries);
+        let commitment_data = construct_intermediate_sets(queries).ok_or(Error::OpeningError)?;
 
         let w: Vec<E::G1Affine> = (0..commitment_data.len())
             .map(|_| transcript.read_point().map_err(|_| Error::SamplingError))

--- a/halo2_proofs/src/poly/kzg/multiopen/shplonk.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/shplonk.rs
@@ -153,7 +153,11 @@ mod proptests {
     use super::{construct_intermediate_sets, Commitment, IntermediateSets};
     use ff::FromUniformBytes;
     use halo2curves::bn256::Fr;
-    use proptest::{collection::vec, prelude::*, sample::select};
+    use proptest::{
+        collection::{hash_set, vec},
+        prelude::*,
+        sample::select,
+    };
     use std::convert::TryFrom;
 
     #[derive(Debug, Clone)]
@@ -203,10 +207,16 @@ mod proptests {
     prop_compose! {
         // Mapping from column index to point index.
         fn arb_queries_inner(num_points: usize, num_cols: usize, num_queries: usize)(
-            col_indices in vec(select((0..num_cols).collect::<Vec<_>>()), num_queries),
-            point_indices in vec(select((0..num_points).collect::<Vec<_>>()), num_queries)
+            // Use a HashSet to ensure we sample distinct (column, point) queries.
+            queries in hash_set(
+                (
+                    select((0..num_cols).collect::<Vec<_>>()),
+                    select((0..num_points).collect::<Vec<_>>()),
+                ),
+                num_queries,
+            )
         ) -> Vec<(usize, usize)> {
-            col_indices.into_iter().zip(point_indices).collect()
+            queries.into_iter().collect()
         }
     }
 

--- a/halo2_proofs/src/poly/kzg/multiopen/shplonk.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/shplonk.rs
@@ -4,6 +4,7 @@ mod verifier;
 use std::hash::Hash;
 
 use crate::multicore::IntoParallelIterator;
+use crate::poly::query::exists_query_collision;
 use crate::{poly::query::Query, transcript::ChallengeScalar};
 use ff::Field;
 pub use prover::ProverSHPLONK;
@@ -52,11 +53,14 @@ struct IntermediateSets<F: Field + Hash, Q: Query<F>> {
 
 fn construct_intermediate_sets<F: Field + Hash, I, Q: Query<F, Eval = F>>(
     queries: I,
-) -> IntermediateSets<F, Q>
+) -> Option<IntermediateSets<F, Q>>
 where
     I: IntoIterator<Item = Q> + Clone,
 {
     let queries = queries.into_iter().collect::<Vec<_>>();
+    if exists_query_collision(&queries) {
+        return None;
+    }
 
     // Find evaluation of a commitment at a rotation
     let get_eval = |commitment: Q::Commitment, rotation: F| -> F {
@@ -137,10 +141,11 @@ where
         })
         .collect::<Vec<RotationSet<_, _>>>();
 
-    IntermediateSets {
+    let sets = IntermediateSets {
         rotation_sets,
         super_point_set,
-    }
+    };
+    Some(sets)
 }
 
 #[cfg(test)]
@@ -233,14 +238,14 @@ mod proptests {
         fn test_intermediate_sets(
             (queries_1, queries_2) in compare_queries(8, 8, 16)
         ) {
-            let IntermediateSets { rotation_sets, .. } = construct_intermediate_sets(queries_1);
+            let IntermediateSets { rotation_sets, .. } = construct_intermediate_sets(queries_1).ok_or_else(|| TestCaseError::Fail("mismatched evals".into()))?;
             let commitment_sets = rotation_sets.iter().map(|data|
                 data.commitments.iter().map(Commitment::get).collect::<Vec<_>>()
             ).collect::<Vec<_>>();
 
             // It shouldn't matter what the point or eval values are; we should get
             // the same exact point set indices and point indices again.
-            let IntermediateSets { rotation_sets: new_rotation_sets, .. } = construct_intermediate_sets(queries_2);
+            let IntermediateSets { rotation_sets: new_rotation_sets, .. } = construct_intermediate_sets(queries_2).ok_or_else(|| TestCaseError::Fail("mismatched evals".into()))?;
             let new_commitment_sets = new_rotation_sets.iter().map(|data|
                 data.commitments.iter().map(Commitment::get).collect::<Vec<_>>()
             ).collect::<Vec<_>>();

--- a/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs
@@ -177,7 +177,12 @@ where
             }
         };
 
-        let intermediate_sets = construct_intermediate_sets(queries);
+        let intermediate_sets = construct_intermediate_sets(queries).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "queries iterator contains mismatching evaluations",
+            )
+        })?;
         let (rotation_sets, super_point_set) = (
             intermediate_sets.rotation_sets,
             intermediate_sets.super_point_set,

--- a/halo2_proofs/src/poly/kzg/multiopen/shplonk/verifier.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/shplonk/verifier.rs
@@ -57,7 +57,7 @@ where
     where
         I: IntoIterator<Item = VerifierQuery<'com, E::G1Affine, MSMKZG<E>>> + Clone,
     {
-        let intermediate_sets = construct_intermediate_sets(queries);
+        let intermediate_sets = construct_intermediate_sets(queries).ok_or(Error::OpeningError)?;
         let (rotation_sets, super_point_set) = (
             intermediate_sets.rotation_sets,
             intermediate_sets.super_point_set,

--- a/halo2_proofs/src/poly/multiopen_test.rs
+++ b/halo2_proofs/src/poly/multiopen_test.rs
@@ -160,6 +160,62 @@ mod test {
         >(verifier_params, &proof[..], true);
     }
 
+    #[test]
+    fn test_identical_queries_gwc() {
+        use crate::poly::kzg::commitment::{KZGCommitmentScheme, ParamsKZG};
+        use crate::poly::kzg::multiopen::{ProverGWC, VerifierGWC};
+        use crate::poly::kzg::strategy::AccumulatorStrategy;
+        use halo2curves::bn256::Bn256;
+
+        const K: u32 = 4;
+
+        let params = ParamsKZG::<Bn256>::new(K);
+
+        let proof = create_proof::<
+            KZGCommitmentScheme<Bn256>,
+            ProverGWC<_>,
+            _,
+            Blake2bWrite<_, _, Challenge255<_>>,
+        >(&params);
+
+        let verifier_params = params.verifier_params();
+        verify_identical_queries::<
+            KZGCommitmentScheme<Bn256>,
+            VerifierGWC<_>,
+            _,
+            Blake2bRead<_, _, Challenge255<_>>,
+            AccumulatorStrategy<_>,
+        >(verifier_params, &proof[..]);
+    }
+
+    #[test]
+    fn test_identical_queries_shplonk() {
+        use crate::poly::kzg::commitment::{KZGCommitmentScheme, ParamsKZG};
+        use crate::poly::kzg::multiopen::{ProverSHPLONK, VerifierSHPLONK};
+        use crate::poly::kzg::strategy::AccumulatorStrategy;
+        use halo2curves::bn256::Bn256;
+
+        const K: u32 = 4;
+
+        let params = ParamsKZG::<Bn256>::new(K);
+
+        let proof = create_proof::<
+            KZGCommitmentScheme<Bn256>,
+            ProverSHPLONK<_>,
+            _,
+            Blake2bWrite<_, _, Challenge255<_>>,
+        >(&params);
+
+        let verifier_params = params.verifier_params();
+        verify_identical_queries::<
+            KZGCommitmentScheme<Bn256>,
+            VerifierSHPLONK<_>,
+            _,
+            Blake2bRead<_, _, Challenge255<_>>,
+            AccumulatorStrategy<_>,
+        >(verifier_params, &proof[..]);
+    }
+
     fn verify<
         'a,
         'params,
@@ -294,5 +350,57 @@ mod test {
             .unwrap();
 
         transcript.finalize()
+    }
+
+    fn verify_identical_queries<
+        'a,
+        'params,
+        Scheme: CommitmentScheme,
+        V: Verifier<'params, Scheme>,
+        E: EncodedChallenge<Scheme::Curve>,
+        T: TranscriptReadBuffer<&'a [u8], Scheme::Curve, E>,
+        Strategy: VerificationStrategy<'params, Scheme, V> + std::fmt::Debug,
+    >(
+        params: &'params Scheme::ParamsVerifier,
+        proof: &'a [u8],
+    ) where
+        Strategy::Output: std::fmt::Debug,
+    {
+        use assert_matches::assert_matches;
+        use group::ff::Field;
+
+        let verifier = V::new(params);
+
+        let mut transcript = T::init(proof);
+
+        let a = transcript.read_point().unwrap();
+        let b = transcript.read_point().unwrap();
+        let c = transcript.read_point().unwrap();
+
+        let x = transcript.squeeze_challenge();
+        let y = transcript.squeeze_challenge();
+
+        let avx = transcript.read_scalar().unwrap();
+        let bvx = transcript.read_scalar().unwrap();
+        let cvy = transcript.read_scalar().unwrap();
+
+        let bvx_bad = <Scheme as CommitmentScheme>::Scalar::random(OsRng);
+
+        #[rustfmt::skip]
+        let invalid_queries = std::iter::empty()
+            .chain(Some(VerifierQuery::new_commitment(&a, x.get_scalar(), avx)))
+            .chain(Some(VerifierQuery::new_commitment(&b, x.get_scalar(), bvx)))
+            .chain(Some(VerifierQuery::new_commitment(&b, x.get_scalar(), bvx_bad))) // This is wrong.
+            .chain(Some(VerifierQuery::new_commitment(&c, y.get_scalar(), cvy)));
+
+        let strategy = Strategy::new(params);
+        assert_matches!(
+            strategy.process(|msm_accumulator| {
+                verifier
+                    .verify_proof(&mut transcript, invalid_queries.clone(), msm_accumulator)
+                    .map_err(|_| Error::Opening)
+            }),
+            Err(Error::Opening)
+        );
     }
 }

--- a/halo2_proofs/src/poly/query.rs
+++ b/halo2_proofs/src/poly/query.rs
@@ -135,3 +135,22 @@ impl<'com, C: CurveAffine, M: MSM<C>> Query<C::Scalar> for VerifierQuery<'com, C
         self.commitment
     }
 }
+
+// Caller tried to provide two different evaluations for the same
+// commitment. Permitting this would be unsound.
+pub(crate) fn exists_query_collision<F, Q>(queries: &[Q]) -> bool
+where
+    F: PartialEq + Copy,
+    Q: Query<F>,
+{
+    let mut query_set: Vec<(Q::Commitment, F)> = Vec::with_capacity(queries.len());
+    for query in queries.iter() {
+        let commitment = query.get_commitment();
+        let rotation = query.get_point();
+        if query_set.contains(&(commitment, rotation)) {
+            return true;
+        }
+        query_set.push((commitment, rotation));
+    }
+    false
+}


### PR DESCRIPTION
This is manually cherry-picked from https://github.com/privacy-scaling-explorations/halo2/pull/400 with an addition of a `exists_query_collision` function to reduce code duplication.

The above fix by PSE is based on the ZCash patch in https://github.com/zcash/halo2/pull/846

The bug was reported by Suneal from zkSecurity: https://blog.zksecurity.xyz/posts/halo2-query-collision/

**NOTE:** This does not affect circuits that only query rotations that are much smaller than the (fixed) witness matrix height. In particular, it does not affect `halo2-lib`.