### PR TITLE
refactor(poly): parameterized Polynomial

### DIFF
--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -66,124 +66,232 @@ impl Basis for LagrangeCoeff {}
 pub struct ExtendedLagrangeCoeff;
 impl Basis for ExtendedLagrangeCoeff {}
 
+/// Residency marker for a [`Polynomial`]. Implementors associate the backing
+/// container type via the [`Storage::Backing`] GAT: `Vec<F>` for [`Host`].
+/// Generic over `F` so a single marker can type every scalar choice the prover
+/// instantiates.
+pub trait Storage: 'static {
+    /// Backing container holding the polynomial's coefficients.
+    type Backing<F>;
+
+    /// Length of the backing container in elements.
+    fn backing_len<F>(b: &Self::Backing<F>) -> usize;
+
+    /// Compile-time tag distinguishing the storage flavours. Used by the few
+    /// code paths that are generic over `S` and want to take a runtime-fast
+    /// branch without virtual dispatch (the optimiser folds the branch since
+    /// `IS_DEVICE` is `const`).
+    const IS_DEVICE: bool;
+}
+
+/// Marker indicating a host-resident polynomial whose coefficients live in a
+/// `Vec<F>`.
+#[derive(Clone, Copy, Debug)]
+pub struct Host;
+
+impl Storage for Host {
+    type Backing<F> = Vec<F>;
+    fn backing_len<F>(b: &Vec<F>) -> usize {
+        b.len()
+    }
+    const IS_DEVICE: bool = false;
+}
+
 /// Represents a univariate polynomial defined over a field and a particular
-/// basis.
-#[derive(Clone, Debug)]
-pub struct Polynomial<F, B> {
-    pub(crate) values: Vec<F>,
+/// basis, parameterised by its storage residency.
+pub struct Polynomial<F, B, S: Storage = Host> {
+    storage: S::Backing<F>,
     _marker: PhantomData<B>,
 }
 
-impl<F, B> Index<usize> for Polynomial<F, B> {
-    type Output = F;
-
-    fn index(&self, index: usize) -> &F {
-        self.values.index(index)
+impl<F, B, S: Storage> Debug for Polynomial<F, B, S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Polynomial")
+            .field("len", &S::backing_len::<F>(&self.storage))
+            .field("residency", &if S::IS_DEVICE { "Device" } else { "Host" })
+            .finish()
     }
 }
 
-impl<F, B> IndexMut<usize> for Polynomial<F, B> {
-    fn index_mut(&mut self, index: usize) -> &mut F {
-        self.values.index_mut(index)
+impl<F: Clone, B> Clone for Polynomial<F, B, Host> {
+    fn clone(&self) -> Self {
+        Self {
+            storage: self.storage.clone(),
+            _marker: PhantomData,
+        }
     }
 }
 
-impl<F, B> Index<Range<usize>> for Polynomial<F, B> {
-    type Output = [F];
-
-    fn index(&self, index: Range<usize>) -> &[F] {
-        self.values.index(index)
-    }
-}
-
-impl<F, B> Index<RangeFrom<usize>> for Polynomial<F, B> {
-    type Output = [F];
-
-    fn index(&self, index: RangeFrom<usize>) -> &[F] {
-        self.values.index(index)
-    }
-}
-
-impl<F, B> IndexMut<Range<usize>> for Polynomial<F, B> {
-    fn index_mut(&mut self, index: Range<usize>) -> &mut [F] {
-        self.values.index_mut(index)
-    }
-}
-
-impl<F, B> IndexMut<RangeFrom<usize>> for Polynomial<F, B> {
-    fn index_mut(&mut self, index: RangeFrom<usize>) -> &mut [F] {
-        self.values.index_mut(index)
-    }
-}
-
-impl<F, B> Index<RangeFull> for Polynomial<F, B> {
-    type Output = [F];
-
-    fn index(&self, index: RangeFull) -> &[F] {
-        self.values.index(index)
-    }
-}
-
-impl<F, B> IndexMut<RangeFull> for Polynomial<F, B> {
-    fn index_mut(&mut self, index: RangeFull) -> &mut [F] {
-        self.values.index_mut(index)
-    }
-}
-
-impl<F, B> Deref for Polynomial<F, B> {
-    type Target = [F];
-
-    fn deref(&self) -> &[F] {
-        &self.values[..]
-    }
-}
-
-impl<F, B> DerefMut for Polynomial<F, B> {
-    fn deref_mut(&mut self) -> &mut [F] {
-        &mut self.values[..]
-    }
-}
-
-impl<F, B> Polynomial<F, B> {
-    /// Iterate over the values, which are either in coefficient or evaluation
-    /// form depending on the basis `B`.
-    pub fn iter(&self) -> impl Iterator<Item = &F> {
-        self.values.iter()
+impl<F, B, S: Storage> Polynomial<F, B, S> {
+    /// Construct a polynomial directly from its backing container. This is the
+    /// generic seam that lets out-of-crate storage backends build a
+    /// `Polynomial` for any `S`.
+    pub fn from_backing(backing: S::Backing<F>) -> Self {
+        Self {
+            storage: backing,
+            _marker: PhantomData,
+        }
     }
 
-    /// Iterate over the values mutably, which are either in coefficient or
-    /// evaluation form depending on the basis `B`.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut F> {
-        self.values.iter_mut()
+    /// Borrow the backing container.
+    pub fn backing(&self) -> &S::Backing<F> {
+        &self.storage
+    }
+
+    /// Mutably borrow the backing container.
+    pub fn backing_mut(&mut self) -> &mut S::Backing<F> {
+        &mut self.storage
+    }
+
+    /// Consume the polynomial and return the owned backing container.
+    pub fn into_backing(self) -> S::Backing<F> {
+        self.storage
+    }
+
+    /// Number of coefficients.
+    pub fn len(&self) -> usize {
+        S::backing_len::<F>(&self.storage)
+    }
+
+    /// `true` if there are no coefficients.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     /// Gets the size of this polynomial in terms of the number of
     /// coefficients used to describe it.
     pub fn num_coeffs(&self) -> usize {
-        self.values.len()
+        self.len()
     }
 }
 
-impl<F: SerdePrimeField, B> Polynomial<F, B> {
+impl<F, B> Polynomial<F, B, Host> {
+    /// Construct a host-resident polynomial directly from `Vec<F>`.
+    pub fn new(values: Vec<F>) -> Self {
+        Self {
+            storage: values,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Direct host slice accessor.
+    pub fn values(&self) -> &[F] {
+        self.storage.as_slice()
+    }
+
+    /// Direct mutable host slice accessor.
+    pub fn values_mut(&mut self) -> &mut [F] {
+        self.storage.as_mut_slice()
+    }
+
+    /// Consume the polynomial and return the owned `Vec<F>` of host
+    /// coefficients.
+    pub fn into_values(self) -> Vec<F> {
+        self.storage
+    }
+
+    /// Iterate over the values, which are either in coefficient or evaluation
+    /// form depending on the basis `B`.
+    pub fn iter(&self) -> impl Iterator<Item = &F> {
+        self.storage.iter()
+    }
+
+    /// Iterate over the values mutably, which are either in coefficient or
+    /// evaluation form depending on the basis `B`.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut F> {
+        self.storage.iter_mut()
+    }
+}
+
+impl<F, B> Index<usize> for Polynomial<F, B, Host> {
+    type Output = F;
+
+    fn index(&self, index: usize) -> &F {
+        &self.values()[index]
+    }
+}
+
+impl<F, B> IndexMut<usize> for Polynomial<F, B, Host> {
+    fn index_mut(&mut self, index: usize) -> &mut F {
+        &mut self.values_mut()[index]
+    }
+}
+
+impl<F, B> Index<Range<usize>> for Polynomial<F, B, Host> {
+    type Output = [F];
+
+    fn index(&self, index: Range<usize>) -> &[F] {
+        &self.values()[index]
+    }
+}
+
+impl<F, B> Index<RangeFrom<usize>> for Polynomial<F, B, Host> {
+    type Output = [F];
+
+    fn index(&self, index: RangeFrom<usize>) -> &[F] {
+        &self.values()[index]
+    }
+}
+
+impl<F, B> IndexMut<Range<usize>> for Polynomial<F, B, Host> {
+    fn index_mut(&mut self, index: Range<usize>) -> &mut [F] {
+        &mut self.values_mut()[index]
+    }
+}
+
+impl<F, B> IndexMut<RangeFrom<usize>> for Polynomial<F, B, Host> {
+    fn index_mut(&mut self, index: RangeFrom<usize>) -> &mut [F] {
+        &mut self.values_mut()[index]
+    }
+}
+
+impl<F, B> Index<RangeFull> for Polynomial<F, B, Host> {
+    type Output = [F];
+
+    fn index(&self, _index: RangeFull) -> &[F] {
+        self.values()
+    }
+}
+
+impl<F, B> IndexMut<RangeFull> for Polynomial<F, B, Host> {
+    fn index_mut(&mut self, index: RangeFull) -> &mut [F] {
+        &mut self.values_mut()[index]
+    }
+}
+
+impl<F, B> Deref for Polynomial<F, B, Host> {
+    type Target = [F];
+
+    fn deref(&self) -> &[F] {
+        self.values()
+    }
+}
+
+impl<F, B> DerefMut for Polynomial<F, B, Host> {
+    fn deref_mut(&mut self) -> &mut [F] {
+        self.values_mut()
+    }
+}
+
+impl<F: SerdePrimeField, B> Polynomial<F, B, Host> {
     /// Reads polynomial from buffer using `SerdePrimeField::read`.
     pub(crate) fn read<R: io::Read>(reader: &mut R, format: SerdeFormat) -> Self {
         let mut poly_len = [0u8; 4];
         reader.read_exact(&mut poly_len).unwrap();
         let poly_len = u32::from_be_bytes(poly_len);
-        Self {
-            values: (0..poly_len)
-                .map(|_| F::read(reader, format).unwrap())
-                .collect(),
-            _marker: PhantomData,
-        }
+        let values: Vec<F> = (0..poly_len)
+            .map(|_| F::read(reader, format).unwrap())
+            .collect();
+        Self::new(values)
     }
 
     /// Writes polynomial to buffer using `SerdePrimeField::write`.
     pub(crate) fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) {
+        let values = self.values();
         writer
-            .write_all(&(self.values.len() as u32).to_be_bytes())
+            .write_all(&(values.len() as u32).to_be_bytes())
             .unwrap();
-        for value in self.values.iter() {
+        for value in values.iter() {
             value.write(writer, format).unwrap();
         }
     }
@@ -219,15 +327,13 @@ where
         .zip(assigned_denominators.par_chunks(n))
         .map(|(poly, inv_denoms)| {
             debug_assert_eq!(inv_denoms.len(), poly.as_ref().len());
-            Polynomial {
-                values: poly
-                    .as_ref()
+            Polynomial::new(
+                poly.as_ref()
                     .iter()
                     .zip(inv_denoms.iter())
                     .map(|(a, inv_den)| a.numerator() * inv_den.unwrap_or(F::ONE))
                     .collect(),
-                _marker: PhantomData,
-            }
+            )
         })
         .collect();
 
@@ -237,15 +343,13 @@ where
         .zip(assigned_denominators.chunks(n))
         .map(|(poly, inv_denoms)| {
             debug_assert_eq!(inv_denoms.len(), poly.as_ref().len());
-            Polynomial {
-                values: poly
-                    .as_ref()
+            Polynomial::new(
+                poly.as_ref()
                     .iter()
                     .zip(inv_denoms.iter())
                     .map(|(a, inv_den)| a.numerator() * inv_den.unwrap_or(F::ONE))
                     .collect(),
-                _marker: PhantomData,
-            }
+            )
         })
         .collect();
 }
@@ -255,16 +359,14 @@ impl<F: Field> Polynomial<Assigned<F>, LagrangeCoeff> {
         &self,
         inv_denoms: impl Iterator<Item = F> + ExactSizeIterator,
     ) -> Polynomial<F, LagrangeCoeff> {
-        assert_eq!(inv_denoms.len(), self.values.len());
-        Polynomial {
-            values: self
-                .values
-                .iter()
-                .zip(inv_denoms)
-                .map(|(a, inv_den)| a.numerator() * inv_den)
-                .collect(),
-            _marker: self._marker,
-        }
+        let src = self.values();
+        assert_eq!(inv_denoms.len(), src.len());
+        let values: Vec<F> = src
+            .iter()
+            .zip(inv_denoms)
+            .map(|(a, inv_den)| a.numerator() * inv_den)
+            .collect();
+        Polynomial::new(values)
     }
 }
 
@@ -272,8 +374,9 @@ impl<'a, F: Field, B: Basis> Add<&'a Polynomial<F, B>> for Polynomial<F, B> {
     type Output = Polynomial<F, B>;
 
     fn add(mut self, rhs: &'a Polynomial<F, B>) -> Polynomial<F, B> {
-        parallelize(&mut self.values, |lhs, start| {
-            for (lhs, rhs) in lhs.iter_mut().zip(rhs.values[start..].iter()) {
+        let rhs_slice = rhs.values();
+        parallelize(self.values_mut(), |lhs, start| {
+            for (lhs, rhs) in lhs.iter_mut().zip(rhs_slice[start..].iter()) {
                 *lhs += *rhs;
             }
         });
@@ -286,8 +389,9 @@ impl<'a, F: Field, B: Basis> Sub<&'a Polynomial<F, B>> for Polynomial<F, B> {
     type Output = Polynomial<F, B>;
 
     fn sub(mut self, rhs: &'a Polynomial<F, B>) -> Polynomial<F, B> {
-        parallelize(&mut self.values, |lhs, start| {
-            for (lhs, rhs) in lhs.iter_mut().zip(rhs.values[start..].iter()) {
+        let rhs_slice = rhs.values();
+        parallelize(self.values_mut(), |lhs, start| {
+            for (lhs, rhs) in lhs.iter_mut().zip(rhs_slice[start..].iter()) {
                 *lhs -= *rhs;
             }
         });
@@ -299,16 +403,13 @@ impl<'a, F: Field, B: Basis> Sub<&'a Polynomial<F, B>> for Polynomial<F, B> {
 impl<F: Field> Polynomial<F, LagrangeCoeff> {
     /// Rotates the values in a Lagrange basis polynomial by `Rotation`
     pub fn rotate(&self, rotation: Rotation) -> Polynomial<F, LagrangeCoeff> {
-        let mut values = self.values.clone();
+        let mut values = self.values().to_vec();
         if rotation.0 < 0 {
             values.rotate_right((-rotation.0) as usize);
         } else {
             values.rotate_left(rotation.0 as usize);
         }
-        Polynomial {
-            values,
-            _marker: PhantomData,
-        }
+        Polynomial::new(values)
     }
 }
 
@@ -317,16 +418,13 @@ impl<F: Field, B: Basis> Mul<F> for Polynomial<F, B> {
 
     fn mul(mut self, rhs: F) -> Polynomial<F, B> {
         if rhs == F::ZERO {
-            return Polynomial {
-                values: vec![F::ZERO; self.len()],
-                _marker: PhantomData,
-            };
+            return Polynomial::new(vec![F::ZERO; self.len()]);
         }
         if rhs == F::ONE {
             return self;
         }
 
-        parallelize(&mut self.values, |lhs, _| {
+        parallelize(self.values_mut(), |lhs, _| {
             for lhs in lhs.iter_mut() {
                 *lhs *= rhs;
             }
@@ -341,7 +439,7 @@ impl<'a, F: Field, B: Basis> Sub<F> for &'a Polynomial<F, B> {
 
     fn sub(self, rhs: F) -> Polynomial<F, B> {
         let mut res = self.clone();
-        res.values[0] -= rhs;
+        res.values_mut()[0] -= rhs;
         res
     }
 }

--- a/halo2_proofs/src/poly/domain.rs
+++ b/halo2_proofs/src/poly/domain.rs
@@ -11,7 +11,7 @@ use super::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial, Rotation};
 
 use group::ff::{BatchInvert, Field, WithSmallOrderMulGroup};
 
-use std::{collections::HashMap, marker::PhantomData};
+use std::collections::HashMap;
 
 /// This structure contains precomputed constants and other details needed for
 /// performing operations on an evaluation domain of size $2^k$ and an extended
@@ -168,10 +168,7 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
     pub fn lagrange_from_vec(&self, values: Vec<F>) -> Polynomial<F, LagrangeCoeff> {
         assert_eq!(values.len(), self.n as usize);
 
-        Polynomial {
-            values,
-            _marker: PhantomData,
-        }
+        Polynomial::new(values)
     }
 
     pub fn lagrange_assigned_from_vec(
@@ -180,10 +177,7 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
     ) -> Polynomial<Assigned<F>, LagrangeCoeff> {
         assert_eq!(values.len(), self.n as usize);
 
-        Polynomial {
-            values,
-            _marker: PhantomData,
-        }
+        Polynomial::new(values)
     }
 
     /// Obtains a polynomial in coefficient form when given a vector of
@@ -192,10 +186,7 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
     pub fn coeff_from_vec(&self, values: Vec<F>) -> Polynomial<F, Coeff> {
         assert_eq!(values.len(), self.n as usize);
 
-        Polynomial {
-            values,
-            _marker: PhantomData,
-        }
+        Polynomial::new(values)
     }
 
     /// Obtains a polynomial in ExtendedLagrange form when given a vector of
@@ -212,16 +203,13 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
         let mut transposed = vec![vec![F::ZERO; values.len()]; self.n as usize];
         values.into_iter().enumerate().for_each(|(i, p)| {
             parallelize(&mut transposed, |transposed, start| {
-                for (transposed, p) in transposed.iter_mut().zip(p.values[start..].iter()) {
+                for (transposed, p) in transposed.iter_mut().zip(p.values()[start..].iter()) {
                     transposed[i] = *p;
                 }
             });
         });
 
-        Polynomial {
-            values: transposed.into_iter().flatten().collect(),
-            _marker: PhantomData,
-        }
+        Polynomial::new(transposed.into_iter().flatten().collect())
     }
 
     /// Obtains a polynomial in ExtendedLagrange form when given a vector of
@@ -238,67 +226,46 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
         let mut transposed = vec![vec![F::ZERO; values.len()]; self.n as usize];
         values.into_iter().enumerate().for_each(|(i, p)| {
             parallelize(&mut transposed, |transposed, start| {
-                for (transposed, p) in transposed.iter_mut().zip(p.values[start..].iter()) {
+                for (transposed, p) in transposed.iter_mut().zip(p.values()[start..].iter()) {
                     transposed[i] = *p;
                 }
             });
         });
 
-        Polynomial {
-            values: transposed.into_iter().flatten().collect(),
-            _marker: PhantomData,
-        }
+        Polynomial::new(transposed.into_iter().flatten().collect())
     }
 
     /// Returns an empty (zero) polynomial in the coefficient basis
     pub fn empty_coeff(&self) -> Polynomial<F, Coeff> {
-        Polynomial {
-            values: vec![F::ZERO; self.n as usize],
-            _marker: PhantomData,
-        }
+        Polynomial::new(vec![F::ZERO; self.n as usize])
     }
 
     /// Returns an empty (zero) polynomial in the Lagrange coefficient basis
     pub fn empty_lagrange(&self) -> Polynomial<F, LagrangeCoeff> {
-        Polynomial {
-            values: vec![F::ZERO; self.n as usize],
-            _marker: PhantomData,
-        }
+        Polynomial::new(vec![F::ZERO; self.n as usize])
     }
 
     /// Returns an empty (zero) polynomial in the Lagrange coefficient basis, with
     /// deferred inversions.
     pub(crate) fn empty_lagrange_assigned(&self) -> Polynomial<Assigned<F>, LagrangeCoeff> {
-        Polynomial {
-            values: vec![F::ZERO.into(); self.n as usize],
-            _marker: PhantomData,
-        }
+        Polynomial::new(vec![F::ZERO.into(); self.n as usize])
     }
 
     /// Returns a constant polynomial in the Lagrange coefficient basis
     pub fn constant_lagrange(&self, scalar: F) -> Polynomial<F, LagrangeCoeff> {
-        Polynomial {
-            values: vec![scalar; self.n as usize],
-            _marker: PhantomData,
-        }
+        Polynomial::new(vec![scalar; self.n as usize])
     }
 
     /// Returns an empty (zero) polynomial in the extended Lagrange coefficient
     /// basis
     pub fn empty_extended(&self) -> Polynomial<F, ExtendedLagrangeCoeff> {
-        Polynomial {
-            values: vec![F::ZERO; self.extended_len()],
-            _marker: PhantomData,
-        }
+        Polynomial::new(vec![F::ZERO; self.extended_len()])
     }
 
     /// Returns a constant polynomial in the extended Lagrange coefficient
     /// basis
     pub fn constant_extended(&self, scalar: F) -> Polynomial<F, ExtendedLagrangeCoeff> {
-        Polynomial {
-            values: vec![scalar; self.extended_len()],
-            _marker: PhantomData,
-        }
+        Polynomial::new(vec![scalar; self.extended_len()])
     }
 
     /// This takes us from an n-length vector into the coefficient form.
@@ -306,15 +273,12 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
     /// This function will panic if the provided vector is not the correct
     /// length.
     pub fn lagrange_to_coeff(&self, mut a: Polynomial<F, LagrangeCoeff>) -> Polynomial<F, Coeff> {
-        assert_eq!(a.values.len(), 1 << self.k);
+        assert_eq!(a.values().len(), 1 << self.k);
 
         // Perform inverse FFT to obtain the polynomial in coefficient form
-        self.ifft(&mut a.values, self.omega_inv, self.k, self.ifft_divisor);
+        self.ifft(a.backing_mut(), self.omega_inv, self.k, self.ifft_divisor);
 
-        Polynomial {
-            values: a.values,
-            _marker: PhantomData,
-        }
+        Polynomial::new(a.into_values())
     }
 
     /// This takes us from an n-length coefficient vector into a coset of the extended
@@ -323,19 +287,16 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
         &self,
         p: &Polynomial<F, Coeff>,
     ) -> Polynomial<F, ExtendedLagrangeCoeff> {
-        assert_eq!(p.values.len(), 1 << self.k);
+        assert_eq!(p.values().len(), 1 << self.k);
 
         let mut a = Vec::with_capacity(self.extended_len());
-        a.extend(&p.values);
+        a.extend(p.values());
 
         self.distribute_powers_zeta(&mut a, true);
         a.resize(self.extended_len(), F::ZERO);
         self.fft_inner(&mut a, self.extended_omega, self.extended_k, false);
 
-        Polynomial {
-            values: a,
-            _marker: PhantomData,
-        }
+        Polynomial::new(a)
     }
 
     /// This takes us from an n-length coefficient vector into parts of the
@@ -350,7 +311,7 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
         &self,
         a: &Polynomial<F, Coeff>,
     ) -> Vec<Polynomial<F, LagrangeCoeff>> {
-        assert_eq!(a.values.len(), 1 << self.k);
+        assert_eq!(a.values().len(), 1 << self.k);
 
         let num_parts = self.extended_len() >> self.k;
         let mut extended_omega_factor = F::ONE;
@@ -375,7 +336,7 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
         &self,
         a: &[Polynomial<F, Coeff>],
     ) -> Vec<Vec<Polynomial<F, LagrangeCoeff>>> {
-        assert_eq!(a[0].values.len(), 1 << self.k);
+        assert_eq!(a[0].values().len(), 1 << self.k);
 
         let mut extended_omega_factor = F::ONE;
         let num_parts = self.extended_len() >> self.k;
@@ -402,16 +363,13 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
         mut a: Polynomial<F, Coeff>,
         extended_omega_factor: F,
     ) -> Polynomial<F, LagrangeCoeff> {
-        assert_eq!(a.values.len(), 1 << self.k);
+        assert_eq!(a.values().len(), 1 << self.k);
 
-        self.distribute_powers(&mut a.values, self.g_coset * extended_omega_factor);
+        self.distribute_powers(a.values_mut(), self.g_coset * extended_omega_factor);
         let data = self.get_fft_data(a.len());
-        best_fft(&mut a.values, self.omega, self.k, data, false);
+        best_fft(a.values_mut(), self.omega, self.k, data, false);
 
-        Polynomial {
-            values: a.values,
-            _marker: PhantomData,
-        }
+        Polynomial::new(a.into_values())
     }
 
     /// Rotate the extended domain polynomial over the original domain.
@@ -425,9 +383,9 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
         let mut poly = poly.clone();
 
         if rotation.0 >= 0 {
-            poly.values.rotate_left(new_rotation);
+            poly.values_mut().rotate_left(new_rotation);
         } else {
-            poly.values.rotate_right(new_rotation);
+            poly.values_mut().rotate_right(new_rotation);
         }
 
         poly
@@ -440,11 +398,11 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
     /// length.
     // TODO/FIXME: caller should be responsible for truncating
     pub fn extended_to_coeff(&self, mut a: Polynomial<F, ExtendedLagrangeCoeff>) -> Vec<F> {
-        assert_eq!(a.values.len(), self.extended_len());
+        assert_eq!(a.values().len(), self.extended_len());
 
         // Inverse FFT
         self.ifft(
-            &mut a.values,
+            a.backing_mut(),
             self.extended_omega_inv,
             self.extended_k,
             self.extended_ifft_divisor,
@@ -452,15 +410,15 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
 
         // Distribute powers to move from coset; opposite from the
         // transformation we performed earlier.
-        self.distribute_powers_zeta(&mut a.values, false);
+        self.distribute_powers_zeta(a.values_mut(), false);
 
         // Truncate it to match the size of the quotient polynomial; the
         // evaluation domain might be slightly larger than necessary because
         // it always lies on a power-of-two boundary.
-        a.values
+        a.backing_mut()
             .truncate((&self.n * self.quotient_poly_degree) as usize);
 
-        a.values
+        a.into_values()
     }
 
     /// This takes us from the a list of lagrange-based polynomials with
@@ -495,7 +453,8 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
                 let mut transposed = vec![vec![F::ZERO; a_parts.len()]; self.n as usize];
                 a_parts.into_iter().enumerate().for_each(|(j, p)| {
                     parallelize(&mut transposed, |transposed, start| {
-                        for (transposed, p) in transposed.iter_mut().zip(p.values[start..].iter()) {
+                        for (transposed, p) in transposed.iter_mut().zip(p.values()[start..].iter())
+                        {
                             transposed[j] = *p;
                         }
                     });
@@ -521,7 +480,7 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
             data,
             false,
         );
-        parallelize(&mut result_poly.values, |values, start| {
+        parallelize(result_poly.values_mut(), |values, start| {
             for (value, other) in values.iter_mut().zip(result[start..].iter()) {
                 *value += other;
             }
@@ -535,21 +494,18 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
         &self,
         mut a: Polynomial<F, ExtendedLagrangeCoeff>,
     ) -> Polynomial<F, ExtendedLagrangeCoeff> {
-        assert_eq!(a.values.len(), self.extended_len());
+        assert_eq!(a.values().len(), self.extended_len());
 
         // Divide to obtain the quotient polynomial in the coset evaluation
         // domain.
-        parallelize(&mut a.values, |h, mut index| {
+        parallelize(a.values_mut(), |h, mut index| {
             for h in h {
                 *h *= &self.t_evaluations[index % self.t_evaluations.len()];
                 index += 1;
             }
         });
 
-        Polynomial {
-            values: a.values,
-            _marker: PhantomData,
-        }
+        Polynomial::new(a.into_values())
     }
 
     /// Given a slice of group elements `[a_0, a_1, a_2, ...]`, this returns
@@ -833,7 +789,7 @@ fn test_coeff_to_extended_part() {
         let parts = domain.coeff_to_extended_parts(&poly);
         domain.lagrange_vec_to_extended(parts)
     };
-    assert_eq!(want.values, got.values);
+    assert_eq!(want.values(), got.values());
 }
 
 #[test]
@@ -913,7 +869,7 @@ fn test_lagrange_vecs_to_extended() {
         );
         let poly = {
             let mut p = domain.empty_extended();
-            p.values = poly;
+            p = Polynomial::new(poly);
             p
         };
         want = want + &poly;
@@ -921,7 +877,7 @@ fn test_lagrange_vecs_to_extended() {
     }
     poly_lagrange_vecs.reverse();
     let got = domain.lagrange_vecs_to_extended(poly_lagrange_vecs);
-    assert_eq!(want.values, got.values);
+    assert_eq!(want.values(), got.values());
 }
 
 #[test]
@@ -970,7 +926,7 @@ fn bench_lagrange_vecs_to_extended() {
         );
         let poly = {
             let mut p = domain.empty_extended();
-            p.values = poly;
+            p = Polynomial::new(poly);
             p
         };
         poly_extended_vecs.push(poly);

--- a/halo2_proofs/src/poly/ipa/commitment/prover.rs
+++ b/halo2_proofs/src/poly/ipa/commitment/prover.rs
@@ -80,7 +80,7 @@ pub fn create_proof<
     let mut f = p_prime_blind.0;
 
     // Initialize the vector `p_prime` as the coefficients of the polynomial.
-    let mut p_prime = p_prime_poly.values;
+    let mut p_prime = p_prime_poly.into_values();
     assert_eq!(p_prime.len(), params.n as usize);
 
     // Initialize the vector `b` as the powers of `x_3`. The inner product of

--- a/halo2_proofs/src/poly/ipa/multiopen/prover.rs
+++ b/halo2_proofs/src/poly/ipa/multiopen/prover.rs
@@ -11,7 +11,6 @@ use ff::Field;
 use group::Curve;
 use rand_core::RngCore;
 use std::io;
-use std::marker::PhantomData;
 
 /// IPA multi-open prover
 #[derive(Debug)]
@@ -80,14 +79,11 @@ impl<'params, C: CurveAffine> Prover<'params, IPACommitmentScheme<C>> for Prover
             .fold(None, |q_prime_poly, (points, poly)| {
                 let mut poly = points
                     .iter()
-                    .fold(poly.clone().unwrap().values, |poly, point| {
+                    .fold(poly.clone().unwrap().into_values(), |poly, point| {
                         kate_division(&poly, *point)
                     });
                 poly.resize(self.params.n as usize, C::Scalar::ZERO);
-                let poly = Polynomial {
-                    values: poly,
-                    _marker: PhantomData,
-                };
+                let poly = Polynomial::new(poly);
 
                 if q_prime_poly.is_none() {
                     Some(poly)

--- a/halo2_proofs/src/poly/kzg/multiopen/gwc/prover.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/gwc/prover.rs
@@ -13,7 +13,6 @@ use pairing::Engine;
 use rand_core::RngCore;
 use std::fmt::Debug;
 use std::io;
-use std::marker::PhantomData;
 
 /// Concrete KZG prover with GWC variant
 #[derive(Debug)]
@@ -76,10 +75,7 @@ where
                 .unwrap();
 
             let poly_batch = &poly_batch - eval_batch;
-            let witness_poly = Polynomial {
-                values: kate_division(&poly_batch.values, z),
-                _marker: PhantomData,
-            };
+            let witness_poly = Polynomial::new(kate_division(poly_batch.values(), z));
             let w = self
                 .params
                 .commit(&witness_poly, Blind::default())

--- a/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs
@@ -1,6 +1,5 @@
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::marker::PhantomData;
 use std::ops::MulAssign;
 
 use super::{
@@ -29,9 +28,9 @@ use std::io;
 use crate::multicore::ParallelIterator;
 
 fn div_by_vanishing<F: Field>(poly: Polynomial<F, Coeff>, roots: &[F]) -> Vec<F> {
-    let poly = roots
-        .iter()
-        .fold(poly.values, |poly, point| kate_division(&poly, *point));
+    let poly = roots.iter().fold(poly.into_values(), |poly, point| {
+        kate_division(&poly, *point)
+    });
 
     poly
 }
@@ -45,10 +44,7 @@ impl<'a, C: CurveAffine> Commitment<C::Scalar, PolynomialPointer<'a, C>> {
     fn extend(&self, points: &[C::Scalar]) -> CommitmentExtension<'a, C> {
         let poly = lagrange_interpolate(points, &self.evals()[..]);
 
-        let low_degree_equivalent = Polynomial {
-            values: poly,
-            _marker: PhantomData,
-        };
+        let low_degree_equivalent = Polynomial::new(poly);
 
         CommitmentExtension {
             commitment: self.clone(),
@@ -60,17 +56,17 @@ impl<'a, C: CurveAffine> Commitment<C::Scalar, PolynomialPointer<'a, C>> {
 impl<'a, C: CurveAffine> CommitmentExtension<'a, C> {
     fn linearisation_contribution(&self, u: C::Scalar) -> Polynomial<C::Scalar, Coeff> {
         let p_x = self.commitment.get().poly;
-        let r_eval = eval_polynomial(&self.low_degree_equivalent.values[..], u);
+        let r_eval = eval_polynomial(self.low_degree_equivalent.values(), u);
         p_x - r_eval
     }
 
     fn quotient_contribution(&self) -> Polynomial<C::Scalar, Coeff> {
         let len = self.low_degree_equivalent.len();
         let mut p_x = self.commitment.get().poly.clone();
-        parallelize(&mut p_x.values[0..len], |lhs, start| {
+        parallelize(&mut p_x.values_mut()[0..len], |lhs, start| {
             for (lhs, rhs) in lhs
                 .iter_mut()
-                .zip(self.low_degree_equivalent.values[start..].iter())
+                .zip(self.low_degree_equivalent.values()[start..].iter())
             {
                 *lhs -= *rhs;
             }
@@ -171,10 +167,7 @@ where
             let mut poly = div_by_vanishing(n_x, points);
             poly.resize(self.params.n as usize, E::Fr::ZERO);
 
-            Polynomial {
-                values: poly,
-                _marker: PhantomData,
-            }
+            Polynomial::new(poly)
         };
 
         let intermediate_sets = construct_intermediate_sets(queries).ok_or_else(|| {
@@ -282,7 +275,7 @@ where
         // sanity check
         #[cfg(debug_assertions)]
         {
-            let must_be_zero = eval_polynomial(&l_x.values[..], *u);
+            let must_be_zero = eval_polynomial(l_x.values(), *u);
             assert_eq!(must_be_zero, E::Fr::ZERO);
         }
 
@@ -294,10 +287,7 @@ where
             h_i.mul_assign(z_0_diff_inv)
         }
 
-        let h_x = Polynomial {
-            values: h_x,
-            _marker: PhantomData,
-        };
+        let h_x = Polynomial::new(h_x);
 
         let h = self.params.commit(&h_x, Blind::default()).to_affine();
         transcript.write_point(h)?;


### PR DESCRIPTION

Introduce a `Storage` trait and `Host` marker so `Polynomial<F, B>` becomes `Polynomial<F, B, S: Storage = Host>` with a private `storage: S::Backing<F>` backing (Vec<F> for Host). The `S = Host` default keeps every existing call-site and public signature unchanged, so the public API change is purely additive.

Add a generic seam (`from_backing`/`backing`/`backing_mut`/`into_backing`) plus the ergonomic Host accessors (`new`/`values`/`values_mut`/`into_values`) and re-express every inherent method, trait impl, and free function over the Host backing through these accessors. Arithmetic, FFT, domain ops, and serde encoding are byte-for-byte unchanged.