### PR TITLE
feat(plonk): add additive ProvingKey/ConstraintSystem accessors

### DIFF
--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -323,6 +323,38 @@ pub struct ProvingKey<C: CurveAffine> {
     ev: Evaluator<C>,
 }
 
+impl<C: CurveAffine> ProvingKey<C> {
+    /// Returns the coefficient-basis polynomial `l0` (1 at the first row, 0 elsewhere).
+    pub fn l0(&self) -> &Polynomial<C::Scalar, Coeff> {
+        &self.l0
+    }
+
+    /// Returns the coefficient-basis polynomial `l_last` (1 at the last usable row, 0 elsewhere).
+    pub fn l_last(&self) -> &Polynomial<C::Scalar, Coeff> {
+        &self.l_last
+    }
+
+    /// Returns the coefficient-basis polynomial `l_active_row` (1 on active rows, 0 on blinding rows).
+    pub fn l_active_row(&self) -> &Polynomial<C::Scalar, Coeff> {
+        &self.l_active_row
+    }
+
+    /// Returns the fixed column polynomials in the Lagrange (evaluation) basis.
+    pub fn fixed_values(&self) -> &[Polynomial<C::Scalar, LagrangeCoeff>] {
+        &self.fixed_values
+    }
+
+    /// Returns the fixed column polynomials in the coefficient basis.
+    pub fn fixed_polys(&self) -> &[Polynomial<C::Scalar, Coeff>] {
+        &self.fixed_polys
+    }
+
+    /// Returns the permutation [`permutation::ProvingKey`].
+    pub fn permutation(&self) -> &permutation::ProvingKey<C> {
+        &self.permutation
+    }
+}
+
 impl<C: CurveAffine> ProvingKey<C>
 where
     C::Scalar: FromUniformBytes<64>,

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -211,7 +211,11 @@ impl<C: CurveAffine> VerifyingKey<C> {
                     .unwrap_or(0))
     }
 
-    fn from_parts(
+    /// Assembles a [`VerifyingKey`] from its constituent parts, computing the
+    /// cached `cs_degree` and `transcript_repr` internally. Additive constructor
+    /// exposed (was private) for external (e.g. GPU) keygen that assembles the
+    /// canonical verifying key from independently-computed pieces.
+    pub fn from_parts(
         domain: EvaluationDomain<C::Scalar>,
         fixed_commitments: Vec<C>,
         permutation: permutation::VerifyingKey<C>,
@@ -352,6 +356,33 @@ impl<C: CurveAffine> ProvingKey<C> {
     /// Returns the permutation [`permutation::ProvingKey`].
     pub fn permutation(&self) -> &permutation::ProvingKey<C> {
         &self.permutation
+    }
+
+    /// Assembles a [`ProvingKey`] from its constituent parts. The optimized
+    /// evaluation data structure (`ev`) is derived from `vk.cs()`, exactly as in
+    /// [`ProvingKey::read`]. Additive constructor for external (e.g. GPU) keygen
+    /// that produces the canonical proving key from independently-computed pieces.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_parts(
+        vk: VerifyingKey<C>,
+        l0: Polynomial<C::Scalar, Coeff>,
+        l_last: Polynomial<C::Scalar, Coeff>,
+        l_active_row: Polynomial<C::Scalar, Coeff>,
+        fixed_values: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
+        fixed_polys: Vec<Polynomial<C::Scalar, Coeff>>,
+        permutation: permutation::ProvingKey<C>,
+    ) -> Self {
+        let ev = Evaluator::new(vk.cs());
+        ProvingKey {
+            vk,
+            l0,
+            l_last,
+            l_active_row,
+            fixed_values,
+            fixed_polys,
+            permutation,
+            ev,
+        }
     }
 }
 

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -299,6 +299,14 @@ impl<C: CurveAffine> VerifyingKey<C> {
     pub fn transcript_repr(&self) -> C::Scalar {
         self.transcript_repr
     }
+
+    /// Returns whether selector compression was applied when this key was
+    /// generated. Needed by out-of-crate keygen (e.g. the GPU `keygen_pk`,
+    /// which rebuilds the proving key from an existing `VerifyingKey` and must
+    /// reproduce the vk's selector-compression mode).
+    pub fn compress_selectors(&self) -> bool {
+        self.compress_selectors
+    }
 }
 
 /// Minimal representation of a verification key that can be used to identify

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -2420,6 +2420,22 @@ impl<F: Field> ConstraintSystem<F> {
     pub fn constants(&self) -> &Vec<Column<Fixed>> {
         &self.constants
     }
+
+    /// Returns the number of distinct queries made so far for each advice column.
+    pub fn num_advice_queries(&self) -> &Vec<usize> {
+        &self.num_advice_queries
+    }
+
+    /// Returns the cached map from virtual selectors to the concrete fixed columns
+    /// they were compressed into.
+    pub fn selector_map(&self) -> &Vec<Column<Fixed>> {
+        &self.selector_map
+    }
+
+    /// Returns the explicitly requested minimum degree of the constraint system, if any.
+    pub fn minimum_degree(&self) -> Option<usize> {
+        self.minimum_degree
+    }
 }
 
 /// Exposes the "virtual cells" that can be queried while creating a custom gate or lookup

--- a/halo2_proofs/src/plonk/permutation.rs
+++ b/halo2_proofs/src/plonk/permutation.rs
@@ -88,6 +88,12 @@ pub struct VerifyingKey<C: CurveAffine> {
 }
 
 impl<C: CurveAffine> VerifyingKey<C> {
+    /// Assembles a permutation [`VerifyingKey`] from its sigma-polynomial
+    /// commitments. Additive constructor for external (e.g. GPU) keygen.
+    pub fn from_commitments(commitments: Vec<C>) -> Self {
+        VerifyingKey { commitments }
+    }
+
     /// Returns commitments of sigma polynomials
     pub fn commitments(&self) -> &Vec<C> {
         &self.commitments
@@ -151,6 +157,19 @@ where
 }
 
 impl<C: CurveAffine> ProvingKey<C> {
+    /// Assembles a permutation [`ProvingKey`] from the permutation polynomials
+    /// in the Lagrange (evaluation) basis and their coefficient-basis
+    /// counterparts. Additive constructor for external (e.g. GPU) keygen.
+    pub fn from_parts(
+        permutations: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
+        polys: Vec<Polynomial<C::Scalar, Coeff>>,
+    ) -> Self {
+        ProvingKey {
+            permutations,
+            polys,
+        }
+    }
+
     /// Gets the total number of bytes in the serialization of `self`
     pub(super) fn bytes_length(&self) -> usize {
         polynomial_slice_byte_length(&self.permutations) + polynomial_slice_byte_length(&self.polys)

--- a/halo2_proofs/src/plonk/permutation.rs
+++ b/halo2_proofs/src/plonk/permutation.rs
@@ -124,7 +124,7 @@ impl<C: CurveAffine> VerifyingKey<C> {
 
 /// The proving key for a single permutation argument.
 #[derive(Clone, Debug)]
-pub(crate) struct ProvingKey<C: CurveAffine> {
+pub struct ProvingKey<C: CurveAffine> {
     permutations: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
     pub(super) polys: Vec<Polynomial<C::Scalar, Coeff>>,
 }
@@ -154,5 +154,15 @@ impl<C: CurveAffine> ProvingKey<C> {
     /// Gets the total number of bytes in the serialization of `self`
     pub(super) fn bytes_length(&self) -> usize {
         polynomial_slice_byte_length(&self.permutations) + polynomial_slice_byte_length(&self.polys)
+    }
+
+    /// Returns the permutation polynomials in the Lagrange (evaluation) basis.
+    pub fn permutations(&self) -> &[Polynomial<C::Scalar, LagrangeCoeff>] {
+        &self.permutations
+    }
+
+    /// Returns the permutation polynomials in the coefficient basis.
+    pub fn polys(&self) -> &[Polynomial<C::Scalar, Coeff>] {
+        &self.polys
     }
 }


### PR DESCRIPTION
Adds read-only public accessors so downstream crates can consume a `ProvingKey` without reaching into private fields, in support of making halo2-axiom's ProvingKey the single source-of-truth key struct.

- ProvingKey: `l0`/`l_last`/`l_active_row`, `fixed_values`, `fixed_polys`, `permutation`
- `permutation::ProvingKey`: `permutations/polys`, and promote the struct to pub
- `ConstraintSystem`: `num_advice_queries`, `selector_map`, `minimum_degree`

Purely additive — no existing signature changes, no behavioral change. Fixes the `l0`/`l_last` doc comments to say "coefficient basis" (they return `Coeff`).