### PR TITLE
feat(plonk): expose shared serde, transcript, and arithmetic helpers as pub

### DIFF
--- a/halo2_proofs/src/arithmetic.rs
+++ b/halo2_proofs/src/arithmetic.rs
@@ -294,7 +294,7 @@ pub(crate) fn evaluate_vanishing_polynomial<F: Field>(roots: &[F], z: F) -> F {
     }
 }
 
-pub(crate) fn powers<F: Field>(base: F) -> impl Iterator<Item = F> {
+pub fn powers<F: Field>(base: F) -> impl Iterator<Item = F> {
     std::iter::successors(Some(F::ONE), move |power| Some(base * power))
 }
 

--- a/halo2_proofs/src/helpers.rs
+++ b/halo2_proofs/src/helpers.rs
@@ -20,7 +20,7 @@ pub enum SerdeFormat {
 }
 
 // Keep this trait for compatibility with IPA serialization
-pub(crate) trait CurveRead: CurveAffine {
+pub trait CurveRead: CurveAffine {
     /// Reads a compressed element from the buffer and attempts to parse it
     /// using `from_bytes`.
     fn read<R: io::Read>(reader: &mut R) -> io::Result<Self> {

--- a/halo2_proofs/src/lib.rs
+++ b/halo2_proofs/src/lib.rs
@@ -22,4 +22,4 @@ pub mod transcript;
 
 pub mod dev;
 mod helpers;
-pub use helpers::SerdeFormat;
+pub use helpers::{CurveRead, SerdeCurveAffine, SerdeFormat, SerdePrimeField};

--- a/halo2_proofs/src/transcript.rs
+++ b/halo2_proofs/src/transcript.rs
@@ -539,14 +539,14 @@ where
     }
 }
 
-pub(crate) fn read_n_points<C: CurveAffine, E: EncodedChallenge<C>, T: TranscriptRead<C, E>>(
+pub fn read_n_points<C: CurveAffine, E: EncodedChallenge<C>, T: TranscriptRead<C, E>>(
     transcript: &mut T,
     n: usize,
 ) -> io::Result<Vec<C>> {
     (0..n).map(|_| transcript.read_point()).collect()
 }
 
-pub(crate) fn read_n_scalars<C: CurveAffine, E: EncodedChallenge<C>, T: TranscriptRead<C, E>>(
+pub fn read_n_scalars<C: CurveAffine, E: EncodedChallenge<C>, T: TranscriptRead<C, E>>(
     transcript: &mut T,
     n: usize,
 ) -> io::Result<Vec<C::Scalar>> {


### PR DESCRIPTION
Widens the visibility of six helpers that are already used internally, so downstream crates can re-export them instead of maintaining byte-identical copies. 

Exposed (all additive — `pub(crate)`/private-module → `pub`, no signature or behavior change):

- `helpers::CurveRead` — `pub(crate)` trait → `pub`

- `helpers::SerdeCurveAffine`, `helpers::SerdePrimeField` — already pub traits, now re-exported from the crate root (were trapped in the private `helpers` module)

- `transcript::read_n_points`, `transcript::read_n_scalars` — `pub(crate)` → `pub`

- `arithmetic::powers` — `pub(crate)` → `pub`

No existing public signature changes, no logic changes — purely a visibility/re-export widening. Blanket impls (`impl<C: CurveAffine> CurveRead for C`, etc.) are unaffected and carry over to consumers.